### PR TITLE
Implement user level progression

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -129,6 +129,35 @@ button:hover {
   font-size: 0.8rem;
 }
 
+/* Información de nivel del usuario */
+.level-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 0.75rem;
+  min-width: 100px;
+}
+.level-info .level-label {
+  font-weight: bold;
+}
+.level-info .level-bar {
+  width: 100%;
+  height: 6px;
+  background: #444;
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 2px 0;
+}
+.level-info .level-bar .level-bar-fill {
+  background: var(--accent);
+  width: 0%;
+  height: 100%;
+  transition: width 0.2s;
+}
+.level-info .level-progress-text {
+  color: var(--text-light);
+}
+
 /* Botón para controlar música en header (sprite) */
 #music-toggle {
   position: fixed;

--- a/index.html
+++ b/index.html
@@ -68,6 +68,13 @@
           <span class="value" id="speed-value">100</span><small></small>
         </div>
       </div>
+      <div class="level-info">
+        <div class="level-label">Level <span id="user-level">1</span></div>
+        <div class="level-bar">
+          <div class="level-bar-fill" id="level-bar-fill"></div>
+        </div>
+        <div class="level-progress-text" id="level-progress-text">0 / 15000</div>
+      </div>
     </header>
 
     <!-- Contenido Principal -->

--- a/js/GameManager.js
+++ b/js/GameManager.js
@@ -33,6 +33,7 @@ export class GameManager {
     this.pollen = 0;
     this.prodLevel = 0;
     this.hiveLevel = 0;
+    this.userLevel = 1;
 
     // Parámetros iniciales y ratios (copiados de ColmenaApp.DEFAULTS)
     this.initialFreeBees = 1;
@@ -103,6 +104,16 @@ export class GameManager {
     return this.baseRates.nectarPerBee * (1 + this.prodLevel * 0.1);
   }
 
+  _levelRequirement(level) {
+    return Math.floor(15000 * Math.pow(level, 1.7));
+  }
+
+  _checkLevelUp() {
+    while (this.pollen >= this._levelRequirement(this.userLevel)) {
+      this.userLevel++;
+    }
+  }
+
   // -------------------------------------------------
   // Lógica de compra (cada método actualiza estado, reproduce SFX y llama a updateAll)
   // -------------------------------------------------
@@ -170,12 +181,15 @@ export class GameManager {
   _updateAllUI() {
     // 1. Refrescar ResourceBar:
     const speedPercent = (1 + this.hiveLevel * 0.05) * 100;
+    const levelReq = this._levelRequirement(this.userLevel);
     this.resourceBar.refresh(
       this.bees.length,
       this.wasps.length,
       this.pollen,
       this.nectar,
-      speedPercent
+      speedPercent,
+      this.userLevel,
+      levelReq
     );
 
     // 2. Refrescar cada UpgradeCard con su coste, valor y si se puede pagar:
@@ -234,6 +248,8 @@ export class GameManager {
     this.wasps.forEach((wasp) =>
       this.threeScene._moveInOrbit(wasp, delta, hiveCenter)
     );
+
+    this._checkLevelUp();
 
     // 5) Finalmente, actualizamos UI para reflejar cambios
     this._updateAllUI();

--- a/js/components/ResourceBar.js
+++ b/js/components/ResourceBar.js
@@ -21,6 +21,9 @@ export class ResourceBar {
     this.pollenEl = getElement("#pollen-value");
     this.nectarEl = getElement("#nectar-value");
     this.speedEl = getElement("#speed-value");
+    this.levelEl = getElement("#user-level");
+    this.levelFillEl = getElement("#level-bar-fill");
+    this.levelProgressTextEl = getElement("#level-progress-text");
   }
 
   /**
@@ -31,11 +34,27 @@ export class ResourceBar {
    * @param {number} nectar
    * @param {number} speedPercent - ya en porcentaje (por ejemplo 120 para “120%”) sin el símbolo
    */
-  refresh(beesCount, waspsCount, pollen, nectar, speedPercent) {
+  refresh(
+    beesCount,
+    waspsCount,
+    pollen,
+    nectar,
+    speedPercent,
+    userLevel,
+    levelRequirement
+  ) {
     this.beeEl.textContent = formatNumber(beesCount);
     this.waspEl.textContent = formatNumber(waspsCount);
     this.pollenEl.textContent = formatNumber(Math.floor(pollen));
     this.nectarEl.textContent = formatNumber(Math.floor(nectar));
     this.speedEl.textContent = formatNumber(Math.round(speedPercent));
+    if (userLevel && levelRequirement) {
+      this.levelEl.textContent = userLevel;
+      const progress = Math.min(pollen / levelRequirement, 1);
+      this.levelFillEl.style.width = `${progress * 100}%`;
+      this.levelProgressTextEl.textContent = `${formatNumber(
+        Math.floor(pollen)
+      )} / ${formatNumber(levelRequirement)}`;
+    }
   }
 }

--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -51,6 +51,39 @@
   }
 }
 
+/* Información de nivel del usuario */
+.level-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 0.75rem;
+  min-width: 100px;
+
+  .level-label {
+    font-weight: bold;
+  }
+
+  .level-bar {
+    width: 100%;
+    height: 6px;
+    background: #444;
+    border-radius: 4px;
+    overflow: hidden;
+    margin: 2px 0;
+
+    .level-bar-fill {
+      background: var(--accent);
+      width: 0%;
+      height: 100%;
+      transition: width 0.2s;
+    }
+  }
+
+  .level-progress-text {
+    color: var(--text-light);
+  }
+}
+
 /* Botón para controlar música en header (sprite) */
 #music-toggle {
   position: fixed;


### PR DESCRIPTION
## Summary
- display user level with progress in the header
- style new level progress bar
- track user level in `GameManager`
- update `ResourceBar` to show level status

## Testing
- `npm install`
- `npm run build-css`


------
https://chatgpt.com/codex/tasks/task_e_683f50f37ba08333baecb73ea2c16865