### PR TITLE
Fix card unlocks and level-up animation

### DIFF
--- a/js/GameManager.js
+++ b/js/GameManager.js
@@ -50,6 +50,14 @@ export class GameManager {
       pollenRatio: 0.2,
     };
 
+    this.cardLevelReq = {
+      contratar: 1,
+      avispa: 2,
+      produccion: 5,
+      'mejorar-colmena': 7,
+      pato: 10
+    };
+
     // Configuramos el hiveSpeedMultiplier en ThreeScene
     // Equivalente a: 1 + this.hiveLevel * 0.05
     this.threeScene.setHiveSpeedMultiplier(() => 1 + this.hiveLevel * 0.05);
@@ -78,6 +86,8 @@ export class GameManager {
         }
       };
     });
+
+    this._updateCardLocks();
 
   }
 
@@ -122,7 +132,18 @@ export class GameManager {
   _checkLevelUp() {
     while (this.pollenLifetime >= this._levelRequirement(this.userLevel)) {
       this.userLevel++;
+      if (this.threeScene.lightCone && typeof this.threeScene.lightCone.triggerAnimation === 'function') {
+        this.threeScene.lightCone.triggerAnimation();
+      }
+      this._updateCardLocks();
     }
+  }
+
+  _updateCardLocks() {
+    this.upgradeCards.forEach(card => {
+      const req = this.cardLevelReq[card.upgradeType] ?? 1;
+      card.setLocked(this.userLevel < req);
+    });
   }
 
   // -------------------------------------------------

--- a/js/components/UpgradeCard.js
+++ b/js/components/UpgradeCard.js
@@ -21,6 +21,9 @@ export class UpgradeCard {
     this.upgradeType = element.dataset.upgrade; // "contratar", "avispa", "produccion" o "mejorar-colmena"
     this.onClickCallback = onClickCallback;
 
+    this.lockOverlay = element.querySelector('.lock-overlay');
+    this.isLocked = this.element.classList.contains('locked');
+
     this.costEl = element.querySelector(".cost span:not(.icon)"); // el <span> que contiene el número
     // Dependiendo del tipo de tarjeta, el valor puede estar en lugares distintos
     if (this.upgradeType === "produccion") {
@@ -34,10 +37,26 @@ export class UpgradeCard {
 
     // Listener al botón de compra
     this.element.addEventListener("click", () => {
+      if (this.isLocked) return;
       if (typeof this.onClickCallback === "function") {
         this.onClickCallback(this.upgradeType);
       }
     });
+  }
+
+  setLocked(locked, text = null) {
+    this.isLocked = locked;
+    this.element.classList.toggle('locked', locked);
+    if (this.lockOverlay) {
+      if (text !== null) {
+        const textEl = this.lockOverlay.querySelector('.lock-text');
+        if (textEl) textEl.textContent = text;
+      }
+      if (!locked) {
+        this.lockOverlay.style.opacity = '';
+        this.lockOverlay.style.visibility = '';
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- trigger LightCone animation on level up
- block upgrade cards until reaching required level

## Testing
- `npm run build-css`


------
https://chatgpt.com/codex/tasks/task_e_683f714d753c8333a7ff44559d75a94a