### PR TITLE
Dynamic upgrade card creation

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,81 +85,94 @@
       <div class="upgrade-bar">
         <button class="upgrade-toggle" aria-expanded="false" aria-label="Show upgrades">
         </button>
-        <div class="content-scroll">
-          <div class="upgrade-card" data-upgrade="contratar">
-            <div class="icon"><img src="assets/images/icon-bee.png" alt="Bee"></div>
-            <div class="info">
-              <h2>Hire Bee</h2>
-              <p class="description">Generates 1 pollen/s</p>
-              <div class="cost">
-                <span class="icon"><img src="assets/images/icon-polen.png" alt="Pollen"></span>
-                <span id="bee-cost">0</span>
-              </div>
-              <div class="count">Amount: <span id="bee-value">0</span></div>
-            </div>
-          </div>
-          <div class="upgrade-card" data-upgrade="avispa">
-            <div class="icon"><img src="assets/images/icon-wasp.png" alt="Wasp"></div>
-            <div class="info">
-              <h2>Hire Wasp</h2>
-              <p class="description">Generates 1.5 pollen/s</p>
-              <div class="cost">
-                <span class="icon"><img src="assets/images/icon-polen.png" alt="Polen"></span>
-                <span id="wasp-cost">0</span>
-              </div>
-              <div class="count">Amount: <span id="wasp-value">0</span></div>
-            </div>
-            <div class="lock-overlay">
-              <span class="lock-icon">🔒</span>
-              <span class="lock-text">Recolecta 500 néctar</span>
-            </div>
-          </div>
-          <div class="upgrade-card" data-upgrade="produccion">
-            <div class="icon"><img src="assets/images/icon-production.png" alt="Energy"></div>
-            <div class="info">
-              <h2>Improve Production</h2>
-              <div class="effect">+<span id="prod-value">0</span>% / bee</div>
-              <p class="cost"><span class="icon"><img src="assets/images/icon-nectar.png" alt="Nectar"></span> <span id="prod-cost">0</span></p>
-            </div>
-            <div class="lock-overlay">
-              <span class="lock-icon">🔒</span>
-              <span class="lock-text">Recolecta 2500 néctar</span>
-            </div>
-          </div>
-          <div class="upgrade-card" data-upgrade="mejorar-colmena">
-            <div class="icon"><img src="assets/images/icon-energy.png" alt="Energy"></div>
-            <div class="info">
-              <h2>Improve Hive</h2>
-              <p class="description">+<span id="hive-speed">0</span>% speed</p>
-              <div class="cost">
-                <span class="icon"><img src="assets/images/icon-nectar.png" alt="Hive"></span>
-                <span id="hive-cost">0</span>
-              </div>
-            </div>
-            <div class="lock-overlay">
-              <span class="lock-icon">🔒</span>
-              <span class="lock-text">Recolecta 500 néctar</span>
-            </div>
-          </div>
-          <div class="upgrade-card " data-upgrade="pato">
-            <div class="icon"><img src="assets/images/icon-polen.png" alt="Duck"></div>
-            <div class="info">
-              <h2>Hire Duck</h2>
-              <p class="description">Generates 2 pollen/s</p>
-              <div class="cost">
-                <span class="icon"><img src="assets/images/icon-polen.png" alt="Pollen"></span>
-                <span id="duck-cost">0</span>
-              </div>
-              <div class="count">Amount: <span id="duck-value">0</span></div>
-            </div>
-            <div class="lock-overlay">
-              <span class="lock-icon">🔒</span>
-              <span class="lock-text">Recolecta 500 néctar</span>
-            </div>
-          </div>
-        </div>
+        <div class="content-scroll"></div>
       </div>
     </main>
+  </div>
+
+  <!-- Templates for upgrade cards -->
+  <div id="card-templates" style="display:none">
+    <template id="tpl-contratar">
+      <div class="upgrade-card" data-upgrade="contratar">
+        <div class="icon"><img src="assets/images/icon-bee.png" alt="Bee"></div>
+        <div class="info">
+          <h2>Hire Bee</h2>
+          <p class="description">Generates 1 pollen/s</p>
+          <div class="cost">
+            <span class="icon"><img src="assets/images/icon-polen.png" alt="Pollen"></span>
+            <span id="bee-cost">0</span>
+          </div>
+          <div class="count">Amount: <span id="bee-value">0</span></div>
+        </div>
+      </div>
+    </template>
+    <template id="tpl-avispa">
+      <div class="upgrade-card" data-upgrade="avispa">
+        <div class="icon"><img src="assets/images/icon-wasp.png" alt="Wasp"></div>
+        <div class="info">
+          <h2>Hire Wasp</h2>
+          <p class="description">Generates 1.5 pollen/s</p>
+          <div class="cost">
+            <span class="icon"><img src="assets/images/icon-polen.png" alt="Polen"></span>
+            <span id="wasp-cost">0</span>
+          </div>
+          <div class="count">Amount: <span id="wasp-value">0</span></div>
+        </div>
+        <div class="lock-overlay">
+          <span class="lock-icon">🔒</span>
+          <span class="lock-text">Locked</span>
+        </div>
+      </div>
+    </template>
+    <template id="tpl-produccion">
+      <div class="upgrade-card" data-upgrade="produccion">
+        <div class="icon"><img src="assets/images/icon-production.png" alt="Energy"></div>
+        <div class="info">
+          <h2>Improve Production</h2>
+          <div class="effect">+<span id="prod-value">0</span>% / bee</div>
+          <p class="cost"><span class="icon"><img src="assets/images/icon-nectar.png" alt="Nectar"></span> <span id="prod-cost">0</span></p>
+        </div>
+        <div class="lock-overlay">
+          <span class="lock-icon">🔒</span>
+          <span class="lock-text">Locked</span>
+        </div>
+      </div>
+    </template>
+    <template id="tpl-mejorar-colmena">
+      <div class="upgrade-card" data-upgrade="mejorar-colmena">
+        <div class="icon"><img src="assets/images/icon-energy.png" alt="Energy"></div>
+        <div class="info">
+          <h2>Improve Hive</h2>
+          <p class="description">+<span id="hive-speed">0</span>% speed</p>
+          <div class="cost">
+            <span class="icon"><img src="assets/images/icon-nectar.png" alt="Hive"></span>
+            <span id="hive-cost">0</span>
+          </div>
+        </div>
+        <div class="lock-overlay">
+          <span class="lock-icon">🔒</span>
+          <span class="lock-text">Locked</span>
+        </div>
+      </div>
+    </template>
+    <template id="tpl-pato">
+      <div class="upgrade-card" data-upgrade="pato">
+        <div class="icon"><img src="assets/images/icon-polen.png" alt="Duck"></div>
+        <div class="info">
+          <h2>Hire Duck</h2>
+          <p class="description">Generates 2 pollen/s</p>
+          <div class="cost">
+            <span class="icon"><img src="assets/images/icon-polen.png" alt="Pollen"></span>
+            <span id="duck-cost">0</span>
+          </div>
+          <div class="count">Amount: <span id="duck-value">0</span></div>
+        </div>
+        <div class="lock-overlay">
+          <span class="lock-icon">🔒</span>
+          <span class="lock-text">Locked</span>
+        </div>
+      </div>
+    </template>
   </div>
 
   <!-- Incluir SCRIPTS como ES6 modules -->

--- a/js/App.js
+++ b/js/App.js
@@ -60,17 +60,21 @@ class App {
         // 6) Creamos SoundToggle (música)
         this.soundToggle = new SoundToggle(this.threeScene.music);
 
-        // 7) Creamos todas las UpgradeCards a partir del DOM presente
-        const upgradeEls = document.querySelectorAll(".upgrade-card");
-        this.upgradeCards = Array.from(upgradeEls).map(
-          (el) => new UpgradeCard(el, null /* se asigna luego en GameManager */)
-        );
+        // 7) Referencias para la creación dinámica de tarjetas
+        this.upgradeContainer = getElement(".upgrade-bar .content-scroll");
+        const tplContainer = getElement("#card-templates");
+        this.cardTemplates = {};
+        tplContainer.querySelectorAll("template").forEach((tpl) => {
+          const type = tpl.id.replace("tpl-", "");
+          this.cardTemplates[type] = tpl;
+        });
 
-        // 8) Instanciamos GameManager inyectando dependencies
+        // 8) Instanciamos GameManager inyectando dependencias
         this.gameManager = new GameManager(
           this.threeScene,
           this.resourceBar,
-          this.upgradeCards,
+          this.upgradeContainer,
+          this.cardTemplates,
           this.soundToggle
         );
 

--- a/js/GameManager.js
+++ b/js/GameManager.js
@@ -19,11 +19,14 @@ export class GameManager {
    * @param {Array<UpgradeCard>} upgradeCards - lista de instancias UpgradeCard (una por cada tarjeta).
    * @param {SoundToggle} soundToggle - instancia de SoundToggle (para reproducir música/SFX).
    */
-  constructor(threeScene, resourceBar, upgradeCards, soundToggle) {
+  constructor(threeScene, resourceBar, upgradeContainer, templates, soundToggle) {
     this.threeScene = threeScene;
     this.resourceBar = resourceBar;
-    this.upgradeCards = upgradeCards;
+    this.upgradeContainer = upgradeContainer;
+    this.cardTemplates = templates;
     this.soundToggle = soundToggle;
+    this.upgradeCards = [];
+    this.upgradeOrder = ["contratar", "avispa", "produccion", "mejorar-colmena", "pato"];
 
     // personajes del juego
     this.bees = [];
@@ -33,6 +36,8 @@ export class GameManager {
     this.pollen = 0;
     // Polén acumulado durante toda la partida (no se reduce al gastar)
     this.pollenLifetime = 0;
+    // Cantidad de polen acumulado desde que se alcanzó el nivel actual
+    this.levelStartPollen = 0;
     this.prodLevel = 0;
     this.hiveLevel = 0;
     this.userLevel = 1;
@@ -50,35 +55,54 @@ export class GameManager {
       pollenRatio: 0.2,
     };
 
+    this.cardLevelReq = {
+      contratar: 1,
+      avispa: 2,
+      produccion: 5,
+      'mejorar-colmena': 7,
+      pato: 10
+    };
+
     // Configuramos el hiveSpeedMultiplier en ThreeScene
     // Equivalente a: 1 + this.hiveLevel * 0.05
     this.threeScene.setHiveSpeedMultiplier(() => 1 + this.hiveLevel * 0.05);
 
-    // Vinculamos eventos de compra en cada UpgradeCard
-    this.upgradeCards.forEach((card) => {
-      card.onClickCallback = (upgradeType) => {
-        switch (upgradeType) {
-          case "contratar":
-            this._buyBee();
-            break;
-          case "avispa":
-            this._buyWasp();
-            break;
-          case "pato":
-            this._buyDuck();
-            break;
-          case "produccion":
-            this._buyProd();
-            break;
-          case "mejorar-colmena":
-            this._buyHive();
-            break;
-          default:
-            console.warn(`Upgrade desconocido: ${upgradeType}`);
-        }
-      };
-    });
+    // Creamos primeras tarjetas (bee desbloqueada + wasp bloqueada)
+    this._createCard("contratar");
+    const wasp = this._createCard("avispa");
+    wasp.setLocked(true, `Nivel ${this.cardLevelReq["avispa"]}`);
+    this._updateCardLocks();
 
+  }
+
+  _createCard(type) {
+    const tpl = this.cardTemplates[type];
+    if (!tpl) return null;
+    const element = tpl.content.firstElementChild.cloneNode(true);
+    this.upgradeContainer.appendChild(element);
+    const card = new UpgradeCard(element, (upgradeType) => {
+      switch (upgradeType) {
+        case "contratar":
+          this._buyBee();
+          break;
+        case "avispa":
+          this._buyWasp();
+          break;
+        case "pato":
+          this._buyDuck();
+          break;
+        case "produccion":
+          this._buyProd();
+          break;
+        case "mejorar-colmena":
+          this._buyHive();
+          break;
+        default:
+          console.warn(`Upgrade desconocido: ${upgradeType}`);
+      }
+    });
+    this.upgradeCards.push(card);
+    return card;
   }
 
   // -------------------------------------------------
@@ -120,8 +144,32 @@ export class GameManager {
   }
 
   _checkLevelUp() {
-    while (this.pollenLifetime >= this._levelRequirement(this.userLevel)) {
+    while (this.pollenLifetime - this.levelStartPollen >= this._levelRequirement(this.userLevel)) {
       this.userLevel++;
+      this.levelStartPollen = this.pollenLifetime;
+      if (this.threeScene.lightCone && typeof this.threeScene.lightCone.triggerAnimation === 'function') {
+        this.threeScene.lightCone.triggerAnimation();
+      }
+      this._updateCardLocks();
+    }
+  }
+
+  _updateCardLocks() {
+    this.upgradeCards.forEach((card) => {
+      const req = this.cardLevelReq[card.upgradeType] ?? 1;
+      card.setLocked(this.userLevel < req, `Nivel ${req}`);
+    });
+
+    // Mostrar siguiente tarjeta si la última está desbloqueada
+    const lastCard = this.upgradeCards[this.upgradeCards.length - 1];
+    const lastIndex = this.upgradeOrder.indexOf(lastCard.upgradeType);
+    if (!lastCard.isLocked && lastIndex < this.upgradeOrder.length - 1) {
+      const nextType = this.upgradeOrder[lastIndex + 1];
+      if (!this.upgradeCards.find((c) => c.upgradeType === nextType)) {
+        const newCard = this._createCard(nextType);
+        const req = this.cardLevelReq[nextType] ?? 1;
+        newCard.setLocked(this.userLevel < req, `Nivel ${req}`);
+      }
     }
   }
 
@@ -206,6 +254,7 @@ export class GameManager {
     // 1. Refrescar ResourceBar:
     const speedPercent = (1 + this.hiveLevel * 0.05) * 100;
     const levelReq = this._levelRequirement(this.userLevel);
+    const levelProgress = this.pollenLifetime - this.levelStartPollen;
     this.resourceBar.refresh(
       this.bees.length,
       this.wasps.length,
@@ -215,7 +264,7 @@ export class GameManager {
       speedPercent,
       this.userLevel,
       levelReq,
-      this.pollenLifetime
+      levelProgress
     );
 
     // 2. Refrescar cada UpgradeCard con su coste, valor y si se puede pagar:
@@ -223,25 +272,25 @@ export class GameManager {
     const beeCost = this._calcBeeCost();
     const canBuyBee = this.pollen >= beeCost;
     const beeCard = this.upgradeCards.find((c) => c.upgradeType === "contratar");
-    beeCard.refresh(beeCost, this.bees.length, canBuyBee);
+    if (beeCard) beeCard.refresh(beeCost, this.bees.length, canBuyBee);
 
     //    - avispa:
     const waspCost = this._calcWaspCost();
     const canBuyWasp = this.pollen >= waspCost;
     const waspCard = this.upgradeCards.find((c) => c.upgradeType === "avispa");
-    waspCard.refresh(waspCost, this.wasps.length, canBuyWasp);
+    if (waspCard) waspCard.refresh(waspCost, this.wasps.length, canBuyWasp);
 
     //    - duck:
     const duckCost = this._calcDuckCost();
     const canBuyDuck = this.pollen >= duckCost;
     const duckCard = this.upgradeCards.find((c) => c.upgradeType === "pato");
-    duckCard.refresh(duckCost, this.ducks.length, canBuyDuck);
+    if (duckCard) duckCard.refresh(duckCost, this.ducks.length, canBuyDuck);
 
     //    - producción:
     const prodCost = this._calcProdCost();
     const canBuyProd = this.nectar >= prodCost;
     const prodCard = this.upgradeCards.find((c) => c.upgradeType === "produccion");
-    prodCard.refresh(prodCost, this.prodLevel * 10, canBuyProd);
+    if (prodCard) prodCard.refresh(prodCost, this.prodLevel * 10, canBuyProd);
 
     //    - colmena:
     const hiveCost = this._calcHiveCost();
@@ -249,7 +298,7 @@ export class GameManager {
     const hiveCard = this.upgradeCards.find(
       (c) => c.upgradeType === "mejorar-colmena"
     );
-    hiveCard.refresh(hiveCost, this.hiveLevel * 5, canBuyHive);
+    if (hiveCard) hiveCard.refresh(hiveCost, this.hiveLevel * 5, canBuyHive);
   }
 
   // -------------------------------------------------

--- a/js/components/ResourceBar.js
+++ b/js/components/ResourceBar.js
@@ -12,7 +12,7 @@ import { formatNumber } from "../utils/formatNumber.js";
  * - Velocidad de la colmena (“speed-value”).
  *
  * Se instancia pasándole las referencias a los elementos del DOM,
- * luego se llama a `refresh(beesCount, waspsCount, pollen, nectar, speedPercent, userLevel, levelRequirement, lifetimePollen)`.
+ * luego se llama a `refresh(beesCount, waspsCount, pollen, nectar, speedPercent, userLevel, levelRequirement, levelPollen)`.
  */
 export class ResourceBar {
   constructor() {
@@ -36,7 +36,7 @@ export class ResourceBar {
    * @param {number} speedPercent - ya en porcentaje (por ejemplo 120 para “120%”) sin el símbolo
    * @param {number} userLevel - nivel actual del usuario
    * @param {number} levelRequirement - polen total necesario para el siguiente nivel
-   * @param {number} lifetimePollen - polen acumulado a lo largo de la partida
+   * @param {number} levelPollen - polen acumulado desde que se alcanzó el nivel actual
    */
   refresh(
     beesCount,
@@ -47,7 +47,7 @@ export class ResourceBar {
     speedPercent,
     userLevel,
     levelRequirement,
-    lifetimePollen
+    levelPollen
   ) {
     this.beeEl.textContent = formatNumber(beesCount);
     this.waspEl.textContent = formatNumber(waspsCount);
@@ -58,13 +58,13 @@ export class ResourceBar {
     if (
       userLevel !== undefined &&
       levelRequirement !== undefined &&
-      lifetimePollen !== undefined
+      levelPollen !== undefined
     ) {
       this.levelEl.textContent = userLevel;
-      const progress = Math.min(lifetimePollen / levelRequirement, 1);
+      const progress = Math.min(levelPollen / levelRequirement, 1);
       this.levelFillEl.style.width = `${progress * 100}%`;
       this.levelProgressTextEl.textContent = `${formatNumber(
-        Math.floor(lifetimePollen)
+        Math.floor(levelPollen)
       )} / ${formatNumber(levelRequirement)}`;
     }
   }

--- a/js/components/UpgradeCard.js
+++ b/js/components/UpgradeCard.js
@@ -21,6 +21,9 @@ export class UpgradeCard {
     this.upgradeType = element.dataset.upgrade; // "contratar", "avispa", "produccion" o "mejorar-colmena"
     this.onClickCallback = onClickCallback;
 
+    this.lockOverlay = element.querySelector('.lock-overlay');
+    this.isLocked = this.element.classList.contains('locked');
+
     this.costEl = element.querySelector(".cost span:not(.icon)"); // el <span> que contiene el número
     // Dependiendo del tipo de tarjeta, el valor puede estar en lugares distintos
     if (this.upgradeType === "produccion") {
@@ -34,10 +37,26 @@ export class UpgradeCard {
 
     // Listener al botón de compra
     this.element.addEventListener("click", () => {
+      if (this.isLocked) return;
       if (typeof this.onClickCallback === "function") {
         this.onClickCallback(this.upgradeType);
       }
     });
+  }
+
+  setLocked(locked, text = null) {
+    this.isLocked = locked;
+    this.element.classList.toggle('locked', locked);
+    if (this.lockOverlay) {
+      if (text !== null) {
+        const textEl = this.lockOverlay.querySelector('.lock-text');
+        if (textEl) textEl.textContent = text;
+      }
+      if (!locked) {
+        this.lockOverlay.style.opacity = '';
+        this.lockOverlay.style.visibility = '';
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- dynamically create upgrade cards from templates
- unlock cards by level and reveal the next locked card

## Testing
- `npm run build-css`


------
https://chatgpt.com/codex/tasks/task_e_683f714d753c8333a7ff44559d75a94a