### PR TITLE
Fix upgrade card flow with centralized config

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,91 +90,6 @@
     </main>
   </div>
 
-  <!-- Templates for upgrade cards -->
-  <div id="card-templates" style="display:none">
-    <template id="tpl-contratar">
-      <div class="upgrade-card" data-upgrade="contratar">
-        <div class="icon"><img src="assets/images/icon-bee.png" alt="Bee"></div>
-        <div class="info">
-          <h2>Hire Bee</h2>
-          <p class="description">Generates 1 pollen/s</p>
-          <div class="cost">
-            <span class="icon"><img src="assets/images/icon-polen.png" alt="Pollen"></span>
-            <span id="bee-cost">0</span>
-          </div>
-          <div class="count">Amount: <span id="bee-value">0</span></div>
-        </div>
-      </div>
-    </template>
-    <template id="tpl-avispa">
-      <div class="upgrade-card" data-upgrade="avispa">
-        <div class="icon"><img src="assets/images/icon-wasp.png" alt="Wasp"></div>
-        <div class="info">
-          <h2>Hire Wasp</h2>
-          <p class="description">Generates 1.5 pollen/s</p>
-          <div class="cost">
-            <span class="icon"><img src="assets/images/icon-polen.png" alt="Polen"></span>
-            <span id="wasp-cost">0</span>
-          </div>
-          <div class="count">Amount: <span id="wasp-value">0</span></div>
-        </div>
-        <div class="lock-overlay">
-          <span class="lock-icon">🔒</span>
-          <span class="lock-text">Locked</span>
-        </div>
-      </div>
-    </template>
-    <template id="tpl-produccion">
-      <div class="upgrade-card" data-upgrade="produccion">
-        <div class="icon"><img src="assets/images/icon-production.png" alt="Energy"></div>
-        <div class="info">
-          <h2>Improve Production</h2>
-          <div class="effect">+<span id="prod-value">0</span>% / bee</div>
-          <p class="cost"><span class="icon"><img src="assets/images/icon-nectar.png" alt="Nectar"></span> <span id="prod-cost">0</span></p>
-        </div>
-        <div class="lock-overlay">
-          <span class="lock-icon">🔒</span>
-          <span class="lock-text">Locked</span>
-        </div>
-      </div>
-    </template>
-    <template id="tpl-mejorar-colmena">
-      <div class="upgrade-card" data-upgrade="mejorar-colmena">
-        <div class="icon"><img src="assets/images/icon-energy.png" alt="Energy"></div>
-        <div class="info">
-          <h2>Improve Hive</h2>
-          <p class="description">+<span id="hive-speed">0</span>% speed</p>
-          <div class="cost">
-            <span class="icon"><img src="assets/images/icon-nectar.png" alt="Hive"></span>
-            <span id="hive-cost">0</span>
-          </div>
-        </div>
-        <div class="lock-overlay">
-          <span class="lock-icon">🔒</span>
-          <span class="lock-text">Locked</span>
-        </div>
-      </div>
-    </template>
-    <template id="tpl-pato">
-      <div class="upgrade-card" data-upgrade="pato">
-        <div class="icon"><img src="assets/images/icon-polen.png" alt="Duck"></div>
-        <div class="info">
-          <h2>Hire Duck</h2>
-          <p class="description">Generates 2 pollen/s</p>
-          <div class="cost">
-            <span class="icon"><img src="assets/images/icon-polen.png" alt="Pollen"></span>
-            <span id="duck-cost">0</span>
-          </div>
-          <div class="count">Amount: <span id="duck-value">0</span></div>
-        </div>
-        <div class="lock-overlay">
-          <span class="lock-icon">🔒</span>
-          <span class="lock-text">Locked</span>
-        </div>
-      </div>
-    </template>
-  </div>
-
   <!-- Incluir SCRIPTS como ES6 modules -->
   <script type="module" src="js/services/AssetService.js"></script>
   <script type="module" src="js/utils/domHelper.js"></script>
@@ -184,6 +99,7 @@
   <script type="module" src="js/components/ResourceBar.js"></script>
   <script type="module" src="js/components/SoundToggle.js"></script>
   <script type="module" src="js/components/UpgradeCard.js"></script>
+  <script type="module" src="js/config/upgrades.js"></script>
   <script type="module" src="js/components/UpgradeToggle.js"></script>
   <script type="module" src="js/three/ThreeScene.js"></script>
   <script type="module" src="js/GameManager.js"></script>

--- a/js/App.js
+++ b/js/App.js
@@ -5,11 +5,11 @@ import { LoadingScreen } from "./components/LoadingScreen.js";
 import { IntroScreen } from "./components/IntroScreen.js";
 import { ResourceBar } from "./components/ResourceBar.js";
 import { SoundToggle } from "./components/SoundToggle.js";
-import { UpgradeCard } from "./components/UpgradeCard.js";
 import { ThreeScene } from "./three/ThreeScene.js";
 import { GameManager } from "./GameManager.js";
 import { getElement } from "./utils/domHelper.js";
 import { UpgradeToggle } from "./components/UpgradeToggle.js";
+import { upgradeConfig } from "./config/upgrades.js";
 import gsap from "https://esm.sh/gsap";
 /**
  * Clase principal que orquesta el flujo completo:
@@ -60,21 +60,15 @@ class App {
         // 6) Creamos SoundToggle (música)
         this.soundToggle = new SoundToggle(this.threeScene.music);
 
-        // 7) Referencias para la creación dinámica de tarjetas
+        // 7) Contenedor donde se generarán las tarjetas
         this.upgradeContainer = getElement(".upgrade-bar .content-scroll");
-        const tplContainer = getElement("#card-templates");
-        this.cardTemplates = {};
-        tplContainer.querySelectorAll("template").forEach((tpl) => {
-          const type = tpl.id.replace("tpl-", "");
-          this.cardTemplates[type] = tpl;
-        });
 
         // 8) Instanciamos GameManager inyectando dependencias
         this.gameManager = new GameManager(
           this.threeScene,
           this.resourceBar,
           this.upgradeContainer,
-          this.cardTemplates,
+          upgradeConfig,
           this.soundToggle
         );
 

--- a/js/components/UpgradeCard.js
+++ b/js/components/UpgradeCard.js
@@ -1,6 +1,5 @@
 // js/components/UpgradeCard.js
 
-import { getElement, createElement } from "../utils/domHelper.js";
 import { formatNumber } from "../utils/formatNumber.js";
 
 /**
@@ -24,16 +23,8 @@ export class UpgradeCard {
     this.lockOverlay = element.querySelector('.lock-overlay');
     this.isLocked = this.element.classList.contains('locked');
 
-    this.costEl = element.querySelector(".cost span:not(.icon)"); // el <span> que contiene el número
-    // Dependiendo del tipo de tarjeta, el valor puede estar en lugares distintos
-    if (this.upgradeType === "produccion") {
-      this.valueEl = element.querySelector("#prod-value");
-    } else if (this.upgradeType === "mejorar-colmena") {
-      this.valueEl = element.querySelector("#hive-speed");
-    } else {
-      // Abejas y avispas muestran la cantidad dentro de .count
-      this.valueEl = element.querySelector(".count span");
-    }
+    this.costEl = element.querySelector('[data-cost]');
+    this.valueEl = element.querySelector('[data-value]');
 
     // Listener al botón de compra
     this.element.addEventListener("click", () => {

--- a/js/config/upgrades.js
+++ b/js/config/upgrades.js
@@ -1,0 +1,57 @@
+export const upgradeConfig = [
+  {
+    type: 'contratar',
+    order: 0,
+    icon: 'assets/images/icon-bee.png',
+    costIcon: 'assets/images/icon-polen.png',
+    name: 'Hire Bee',
+    description: 'Generates 1 pollen/s',
+    costResource: 'pollen',
+    showAmount: true,
+    levelReq: null
+  },
+  {
+    type: 'avispa',
+    order: 1,
+    icon: 'assets/images/icon-wasp.png',
+    costIcon: 'assets/images/icon-polen.png',
+    name: 'Hire Wasp',
+    description: 'Generates 1.5 pollen/s',
+    costResource: 'pollen',
+    showAmount: true,
+    levelReq: 2
+  },
+  {
+    type: 'produccion',
+    order: 2,
+    icon: 'assets/images/icon-production.png',
+    costIcon: 'assets/images/icon-nectar.png',
+    name: 'Improve Production',
+    description: '+<span data-value></span>% / bee',
+    costResource: 'nectar',
+    showAmount: false,
+    levelReq: 5
+  },
+  {
+    type: 'mejorar-colmena',
+    order: 3,
+    icon: 'assets/images/icon-energy.png',
+    costIcon: 'assets/images/icon-nectar.png',
+    name: 'Improve Hive',
+    description: '+<span data-value></span>% speed',
+    costResource: 'nectar',
+    showAmount: false,
+    levelReq: 7
+  },
+  {
+    type: 'pato',
+    order: 4,
+    icon: 'assets/images/icon-polen.png',
+    costIcon: 'assets/images/icon-polen.png',
+    name: 'Hire Duck',
+    description: 'Generates 2 pollen/s',
+    costResource: 'pollen',
+    showAmount: true,
+    levelReq: 10
+  }
+];

--- a/js/utils/domHelper.js
+++ b/js/utils/domHelper.js
@@ -28,4 +28,3 @@ export function createElement(tag, options = {}, parent) {
   if (parent) parent.appendChild(el);
   return el;
 }
-import gsap from "https://esm.sh/gsap@3.13.0";


### PR DESCRIPTION
## Summary
- centralize upgrade definitions in `js/config/upgrades.js`
- build upgrade cards dynamically from configuration
- remove HTML templates and load config script
- refactor GameManager to use new config and fix card unlocking
- simplify UpgradeCard component selectors
- clean unused code in domHelper

## Testing
- `npm run build-css` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f81a95b0883339b522b750a2a0109