### PR TITLE
Add autosave and continue feature

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -214,6 +214,9 @@ button:hover {
   transition: background 0.2s, transform 0.1s;
   cursor: pointer;
 }
+.intro-button + .intro-button {
+  margin-top: 1rem;
+}
 .intro-button:hover {
   background: var(--accent-hover);
   transform: translateY(-2px);

--- a/index.html
+++ b/index.html
@@ -49,7 +49,8 @@
         alt="Logo Honey Hive Idle"
         class="intro-logo"
       />
-      <button id="btn-play" class="intro-button">PLAY</button>
+      <button id="btn-new-game" class="intro-button">NEW GAME</button>
+      <button id="btn-continue" class="intro-button" disabled>CONTINUE</button>
     </div>
 
     <!-- Header (ResourceBar) -->

--- a/js/App.js
+++ b/js/App.js
@@ -41,8 +41,13 @@ class App {
         return this.loadingScreen.hide().then(() => assets);
       })
       .then((assets) => {
+        const hasSave = !!localStorage.getItem("honeyHiveSave");
         // 2) mostramos el IntroScreen
-        this.introScreen = new IntroScreen(() => this._onPlay());
+        this.introScreen = new IntroScreen(
+          () => this._onNewGame(),
+          () => this._onContinue(),
+          hasSave
+        );
         this.introScreen.show();
 
         // 3) Guardamos los assets
@@ -69,7 +74,8 @@ class App {
           this.resourceBar,
           this.upgradeContainer,
           upgradeConfig,
-          this.soundToggle
+          this.soundToggle,
+          { saveInterval: 30000 }
         );
 
         // 9) Ahora que GameManager está listo, iniciamos el bucle de render
@@ -80,12 +86,7 @@ class App {
       });
   }
 
-  /**
-   * Callback invocado cuando el usuario hace click en “JUGAR” dentro de IntroScreen.
-   * Aquí creamos ThreeScene, UI components (ResourceBar, UpgradeCards, SoundToggle) y GameManager.
-   * Finalmente, arrancamos el bucle de render.
-   */
-  _onPlay() {
+  _startGame() {
     // 4) Ocultamos la intro y simultáneamente mostramos upgrade-bar y header
     this.introScreen.hide();
 
@@ -105,6 +106,18 @@ class App {
 
     // Ejecutamos animación de “playGame” (mover cámara)
     this.threeScene.playGameAnimation();
+  }
+
+  _onNewGame() {
+    this._startGame();
+  }
+
+  _onContinue() {
+    const data = localStorage.getItem("honeyHiveSave");
+    if (data) {
+      this.gameManager.loadState(JSON.parse(data));
+    }
+    this._startGame();
   }
 }
 

--- a/js/GameManager.js
+++ b/js/GameManager.js
@@ -4,6 +4,8 @@ import * as THREE from "https://esm.sh/three@0.174.0";
 import { ResourceBar } from "./components/ResourceBar.js";
 import { UpgradeCard } from "./components/UpgradeCard.js";
 
+const STORAGE_KEY = "honeyHiveSave";
+
 /**
  * GameManager se encarga de:
  * - Mantener el estado del juego (bees, wasps, nectar, pollen, niveles).
@@ -19,7 +21,14 @@ export class GameManager {
    * @param {Array<UpgradeCard>} upgradeCards - lista de instancias UpgradeCard (una por cada tarjeta).
    * @param {SoundToggle} soundToggle - instancia de SoundToggle (para reproducir música/SFX).
    */
-  constructor(threeScene, resourceBar, upgradeContainer, upgradeDefs, soundToggle) {
+  constructor(
+    threeScene,
+    resourceBar,
+    upgradeContainer,
+    upgradeDefs,
+    soundToggle,
+    options = {}
+  ) {
     this.threeScene = threeScene;
     this.resourceBar = resourceBar;
     this.upgradeContainer = upgradeContainer;
@@ -31,6 +40,8 @@ export class GameManager {
     });
     this.soundToggle = soundToggle;
     this.upgradeCards = [];
+
+    this.saveInterval = options.saveInterval || 30000;
 
     // personajes del juego
     this.bees = [];
@@ -76,6 +87,7 @@ export class GameManager {
     }
     this._updateCardLocks();
 
+    this._startAutoSave();
   }
 
   _createCard(type) {
@@ -370,5 +382,65 @@ export class GameManager {
 
     // 6) Finalmente, actualizamos UI para reflejar cambios
     this._updateAllUI();
+  }
+
+  getState() {
+    return {
+      bees: this.bees.length,
+      wasps: this.wasps.length,
+      ducks: this.ducks.length,
+      nectar: this.nectar,
+      pollen: this.pollen,
+      pollenLifetime: this.pollenLifetime,
+      levelStartPollen: this.levelStartPollen,
+      prodLevel: this.prodLevel,
+      hiveLevel: this.hiveLevel,
+      userLevel: this.userLevel,
+    };
+  }
+
+  loadState(state) {
+    if (!state) return;
+    this.nectar = state.nectar || 0;
+    this.pollen = state.pollen || 0;
+    this.pollenLifetime = state.pollenLifetime || 0;
+    this.levelStartPollen = state.levelStartPollen || 0;
+    this.prodLevel = state.prodLevel || 0;
+    this.hiveLevel = state.hiveLevel || 0;
+    this.userLevel = state.userLevel || 1;
+
+    this.threeScene.setHiveSpeedMultiplier(() => 1 + this.hiveLevel * 0.05);
+
+    const spawn = (count, fn) => {
+      for (let i = 0; i < count; i++) {
+        const ent = fn.call(this.threeScene);
+        if (fn === this.threeScene.spawnBee) this.bees.push(ent);
+        else if (fn === this.threeScene.spawnWasp) this.wasps.push(ent);
+        else if (fn === this.threeScene.spawnDuck) this.ducks.push(ent);
+      }
+    };
+    spawn(state.bees || 0, this.threeScene.spawnBee);
+    spawn(state.wasps || 0, this.threeScene.spawnWasp);
+    spawn(state.ducks || 0, this.threeScene.spawnDuck);
+
+    let prev;
+    do {
+      prev = this.upgradeCards.length;
+      this._updateCardLocks();
+    } while (this.upgradeCards.length > prev);
+
+    this._updateAllUI();
+  }
+
+  saveToStorage() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(this.getState()));
+    } catch (e) {
+      console.warn("Failed to save game", e);
+    }
+  }
+
+  _startAutoSave() {
+    setInterval(() => this.saveToStorage(), this.saveInterval);
   }
 }

--- a/js/components/IntroScreen.js
+++ b/js/components/IntroScreen.js
@@ -9,17 +9,31 @@ import { getElement } from "../utils/domHelper.js";
  * - Provee un método para animar la salida de esta intro (fade-out).
  */
 export class IntroScreen {
-  constructor(onPlayCallback) {
+  constructor(onNewGame, onContinue, hasSave = false) {
     this.container = getElement(".intro-screen");
-    this.playButton = getElement("#btn-play");
-    this.onPlayCallback = onPlayCallback;
+    this.newGameButton = getElement("#btn-new-game");
+    this.continueButton = getElement("#btn-continue");
+    this.onNewGame = onNewGame;
+    this.onContinue = onContinue;
 
-    // Al hacer click en “JUGAR”, llamamos al callback
-    this.playButton.addEventListener("click", () => {
-      if (typeof this.onPlayCallback === "function") {
-        this.onPlayCallback();
+    if (this.continueButton) {
+      this.continueButton.disabled = !hasSave;
+    }
+
+    // Al hacer click en “NEW GAME”, llamamos al callback
+    this.newGameButton.addEventListener("click", () => {
+      if (typeof this.onNewGame === "function") {
+        this.onNewGame();
       }
     });
+
+    if (this.continueButton) {
+      this.continueButton.addEventListener("click", () => {
+        if (!this.continueButton.disabled && typeof this.onContinue === "function") {
+          this.onContinue();
+        }
+      });
+    }
   }
 
   /**
@@ -56,11 +70,18 @@ export class IntroScreen {
       { opacity: 0, y: 100, scale: 0.5 },
       { opacity: 1, scale: 1, y: 0, duration: 2, delay: 1 }
     );
-    // Luego hacemos que el botón aparezca
+    // Luego hacemos que los botones aparezcan
     gsap.fromTo(
-      this.playButton,
+      this.newGameButton,
       { opacity: 0, scale: 0.5 },
       { opacity: 1, scale: 1, duration: 1, delay: 2 }
     );
+    if (this.continueButton) {
+      gsap.fromTo(
+        this.continueButton,
+        { opacity: 0, scale: 0.5 },
+        { opacity: 1, scale: 1, duration: 1, delay: 2.2 }
+      );
+    }
   }
 }

--- a/scss/components/_intro-screen.scss
+++ b/scss/components/_intro-screen.scss
@@ -30,6 +30,10 @@
   transition: background 0.2s, transform 0.1s;
   cursor: pointer;
 
+  & + .intro-button {
+    margin-top: 1rem;
+  }
+
   &:hover {
     background: var(--accent-hover);
     transform: translateY(-2px);


### PR DESCRIPTION
## Summary
- introduce Continue option and autosave functionality
- save game state every 30s in localStorage
- add a New Game button and a Continue button on intro screen
- enable Continue when a saved game exists
- update styles for multiple intro buttons

## Testing
- `npm run build-css`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68403e280f348333a74fa16108476f12