### PR TITLE
Add autosave start trigger

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -214,6 +214,9 @@ button:hover {
   transition: background 0.2s, transform 0.1s;
   cursor: pointer;
 }
+.intro-button + .intro-button {
+  margin-top: 1rem;
+}
 .intro-button:hover {
   background: var(--accent-hover);
   transform: translateY(-2px);

--- a/index.html
+++ b/index.html
@@ -49,7 +49,8 @@
         alt="Logo Honey Hive Idle"
         class="intro-logo"
       />
-      <button id="btn-play" class="intro-button">PLAY</button>
+      <button id="btn-new-game" class="intro-button">NEW GAME</button>
+      <button id="btn-continue" class="intro-button" disabled>CONTINUE</button>
     </div>
 
     <!-- Header (ResourceBar) -->

--- a/js/App.js
+++ b/js/App.js
@@ -41,8 +41,13 @@ class App {
         return this.loadingScreen.hide().then(() => assets);
       })
       .then((assets) => {
+        const hasSave = !!localStorage.getItem("honeyHiveSave");
         // 2) mostramos el IntroScreen
-        this.introScreen = new IntroScreen(() => this._onPlay());
+        this.introScreen = new IntroScreen(
+          () => this._onNewGame(),
+          () => this._onContinue(),
+          hasSave
+        );
         this.introScreen.show();
 
         // 3) Guardamos los assets
@@ -69,7 +74,8 @@ class App {
           this.resourceBar,
           this.upgradeContainer,
           upgradeConfig,
-          this.soundToggle
+          this.soundToggle,
+          { saveInterval: 30000 }
         );
 
         // 9) Ahora que GameManager está listo, iniciamos el bucle de render
@@ -80,12 +86,7 @@ class App {
       });
   }
 
-  /**
-   * Callback invocado cuando el usuario hace click en “JUGAR” dentro de IntroScreen.
-   * Aquí creamos ThreeScene, UI components (ResourceBar, UpgradeCards, SoundToggle) y GameManager.
-   * Finalmente, arrancamos el bucle de render.
-   */
-  _onPlay() {
+  _startGame() {
     // 4) Ocultamos la intro y simultáneamente mostramos upgrade-bar y header
     this.introScreen.hide();
 
@@ -105,6 +106,19 @@ class App {
 
     // Ejecutamos animación de “playGame” (mover cámara)
     this.threeScene.playGameAnimation();
+    this.gameManager.startAutoSave();
+  }
+
+  _onNewGame() {
+    this._startGame();
+  }
+
+  _onContinue() {
+    const data = localStorage.getItem("honeyHiveSave");
+    if (data) {
+      this.gameManager.loadState(JSON.parse(data));
+    }
+    this._startGame();
   }
 }
 

--- a/js/components/IntroScreen.js
+++ b/js/components/IntroScreen.js
@@ -9,17 +9,31 @@ import { getElement } from "../utils/domHelper.js";
  * - Provee un método para animar la salida de esta intro (fade-out).
  */
 export class IntroScreen {
-  constructor(onPlayCallback) {
+  constructor(onNewGame, onContinue, hasSave = false) {
     this.container = getElement(".intro-screen");
-    this.playButton = getElement("#btn-play");
-    this.onPlayCallback = onPlayCallback;
+    this.newGameButton = getElement("#btn-new-game");
+    this.continueButton = getElement("#btn-continue");
+    this.onNewGame = onNewGame;
+    this.onContinue = onContinue;
 
-    // Al hacer click en “JUGAR”, llamamos al callback
-    this.playButton.addEventListener("click", () => {
-      if (typeof this.onPlayCallback === "function") {
-        this.onPlayCallback();
+    if (this.continueButton) {
+      this.continueButton.disabled = !hasSave;
+    }
+
+    // Al hacer click en “NEW GAME”, llamamos al callback
+    this.newGameButton.addEventListener("click", () => {
+      if (typeof this.onNewGame === "function") {
+        this.onNewGame();
       }
     });
+
+    if (this.continueButton) {
+      this.continueButton.addEventListener("click", () => {
+        if (!this.continueButton.disabled && typeof this.onContinue === "function") {
+          this.onContinue();
+        }
+      });
+    }
   }
 
   /**
@@ -56,11 +70,18 @@ export class IntroScreen {
       { opacity: 0, y: 100, scale: 0.5 },
       { opacity: 1, scale: 1, y: 0, duration: 2, delay: 1 }
     );
-    // Luego hacemos que el botón aparezca
+    // Luego hacemos que los botones aparezcan
     gsap.fromTo(
-      this.playButton,
+      this.newGameButton,
       { opacity: 0, scale: 0.5 },
       { opacity: 1, scale: 1, duration: 1, delay: 2 }
     );
+    if (this.continueButton) {
+      gsap.fromTo(
+        this.continueButton,
+        { opacity: 0, scale: 0.5 },
+        { opacity: 1, scale: 1, duration: 1, delay: 2.2 }
+      );
+    }
   }
 }

--- a/scss/components/_intro-screen.scss
+++ b/scss/components/_intro-screen.scss
@@ -30,6 +30,10 @@
   transition: background 0.2s, transform 0.1s;
   cursor: pointer;
 
+  & + .intro-button {
+    margin-top: 1rem;
+  }
+
   &:hover {
     background: var(--accent-hover);
     transform: translateY(-2px);


### PR DESCRIPTION
## Summary
- avoid overwriting previous saves by only starting autosave after the game begins
- expose `startAutoSave` and `stopAutoSave` methods in GameManager
- trigger autosave from `_startGame`

## Testing
- `npm run build-css` *(fails: sass not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68403e280f348333a74fa16108476f12