### PR TITLE
Add settings menu

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -502,3 +502,54 @@ button:hover {
 .upgrade-card .info .count span {
   font-weight: bold;
 }
+
+/* ----------------- COMPONENTE: Settings Menu ----------------- */
+.settings-button {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  z-index: 100;
+  background: var(--accent);
+  border: none;
+  color: #222;
+  font-size: 1rem;
+  padding: 6px 8px;
+  border-radius: 8px;
+}
+
+.settings-menu {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+.settings-menu.open {
+  display: flex;
+}
+.settings-menu .settings-content {
+  background: var(--dark-panel);
+  padding: 1rem;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  color: var(--text-white);
+  min-width: 220px;
+}
+.settings-menu .settings-content label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.8rem;
+  gap: 0.25rem;
+}
+.settings-menu .settings-content .close-btn {
+  align-self: flex-end;
+  padding: 4px 8px;
+  background: var(--accent);
+  border: none;
+  border-radius: 6px;
+  color: #222;
+}

--- a/index.html
+++ b/index.html
@@ -83,6 +83,28 @@
       <div class="scene-container">
         <canvas id="three-canvas"></canvas>
       </div>
+      <button id="settings-button" class="settings-button">⚙</button>
+      <div class="settings-menu">
+        <div class="settings-content">
+          <h2>Settings</h2>
+          <label>
+            Music Volume
+            <input type="range" id="music-volume" min="0" max="1" step="0.01" value="0.2">
+          </label>
+          <label>
+            SFX Volume
+            <input type="range" id="sfx-volume" min="0" max="1" step="0.01" value="1">
+          </label>
+          <label>
+            Render Quality
+            <select id="render-quality">
+              <option value="high">High</option>
+              <option value="low">Low</option>
+            </select>
+          </label>
+          <button id="settings-close" class="close-btn">Close</button>
+        </div>
+      </div>
       <div class="upgrade-bar">
         <button class="upgrade-toggle" aria-expanded="false" aria-label="Show upgrades">
         </button>
@@ -99,6 +121,7 @@
   <script type="module" src="js/components/IntroScreen.js"></script>
   <script type="module" src="js/components/ResourceBar.js"></script>
   <script type="module" src="js/components/SoundToggle.js"></script>
+  <script type="module" src="js/components/SettingsMenu.js"></script>
   <script type="module" src="js/components/UpgradeCard.js"></script>
   <script type="module" src="js/config/upgrades.js"></script>
   <script type="module" src="js/components/UpgradeToggle.js"></script>

--- a/js/App.js
+++ b/js/App.js
@@ -5,6 +5,7 @@ import { LoadingScreen } from "./components/LoadingScreen.js";
 import { IntroScreen } from "./components/IntroScreen.js";
 import { ResourceBar } from "./components/ResourceBar.js";
 import { SoundToggle } from "./components/SoundToggle.js";
+import { SettingsMenu } from "./components/SettingsMenu.js";
 import { ThreeScene } from "./three/ThreeScene.js";
 import { GameManager } from "./GameManager.js";
 import { getElement } from "./utils/domHelper.js";
@@ -62,13 +63,16 @@ class App {
         // 5) Creamos ResourceBar (actualiza valores superiores)
         this.resourceBar = new ResourceBar();
 
-        // 6) Creamos SoundToggle (música)
-        this.soundToggle = new SoundToggle(this.threeScene.music);
+          // 6) Creamos SoundToggle (música)
+          this.soundToggle = new SoundToggle(this.threeScene.music);
+
+          // 6b) Configuración de ajustes
+          this.settingsMenu = new SettingsMenu(this.threeScene);
 
         // 7) Contenedor donde se generarán las tarjetas
         this.upgradeContainer = getElement(".upgrade-bar .content-scroll");
 
-        // 8) Instanciamos GameManager inyectando dependencias
+          // 8) Instanciamos GameManager inyectando dependencias
         this.gameManager = new GameManager(
           this.threeScene,
           this.resourceBar,
@@ -107,18 +111,6 @@ class App {
     // Ejecutamos animación de “playGame” (mover cámara)
     this.threeScene.playGameAnimation();
     this.gameManager.startAutoSave();
-  }
-
-  _onNewGame() {
-    this._startGame();
-  }
-
-  _onContinue() {
-    const data = localStorage.getItem("honeyHiveSave");
-    if (data) {
-      this.gameManager.loadState(JSON.parse(data));
-    }
-    this._startGame();
   }
 
   _onNewGame() {

--- a/js/components/SettingsMenu.js
+++ b/js/components/SettingsMenu.js
@@ -1,0 +1,53 @@
+// js/components/SettingsMenu.js
+import { getElement } from "../utils/domHelper.js";
+
+export class SettingsMenu {
+  constructor(threeScene) {
+    this.threeScene = threeScene;
+
+    this.menuEl = getElement(".settings-menu");
+    this.openBtn = getElement("#settings-button");
+    this.closeBtn = getElement("#settings-close");
+    this.musicInput = getElement("#music-volume");
+    this.sfxInput = getElement("#sfx-volume");
+    this.qualitySelect = getElement("#render-quality");
+
+    const saved = JSON.parse(localStorage.getItem("honeyHiveConfig") || "{}");
+    if (saved.musicVolume !== undefined) this.musicInput.value = saved.musicVolume;
+    if (saved.sfxVolume !== undefined) this.sfxInput.value = saved.sfxVolume;
+    if (saved.quality) this.qualitySelect.value = saved.quality;
+
+    this.applySettings();
+
+    this.openBtn.addEventListener("click", () => this.menuEl.classList.add("open"));
+    this.closeBtn.addEventListener("click", () => this.menuEl.classList.remove("open"));
+
+    this.musicInput.addEventListener("input", () => {
+      this.threeScene.setMusicVolume(parseFloat(this.musicInput.value));
+      this._save();
+    });
+    this.sfxInput.addEventListener("input", () => {
+      this.threeScene.setSFXVolume(parseFloat(this.sfxInput.value));
+      this._save();
+    });
+    this.qualitySelect.addEventListener("change", () => {
+      this.threeScene.setQuality(this.qualitySelect.value);
+      this._save();
+    });
+  }
+
+  applySettings() {
+    this.threeScene.setMusicVolume(parseFloat(this.musicInput.value));
+    this.threeScene.setSFXVolume(parseFloat(this.sfxInput.value));
+    this.threeScene.setQuality(this.qualitySelect.value);
+  }
+
+  _save() {
+    const data = {
+      musicVolume: parseFloat(this.musicInput.value),
+      sfxVolume: parseFloat(this.sfxInput.value),
+      quality: this.qualitySelect.value,
+    };
+    localStorage.setItem("honeyHiveConfig", JSON.stringify(data));
+  }
+}

--- a/js/three/ThreeScene.js
+++ b/js/three/ThreeScene.js
@@ -98,11 +98,13 @@ export class ThreeScene {
       antialias: true,
       alpha: true,
     });
+    this.pixelRatio = 1;
     this.renderer.setSize(
       this.containerEl.clientWidth,
       this.containerEl.clientHeight,
       false
     );
+    this.renderer.setPixelRatio(this.pixelRatio);
     this.renderer.shadowMap.enabled = true;
     this.renderer.physicallyCorrectLights = true;
   }
@@ -188,6 +190,27 @@ export class ThreeScene {
     if (this.music && !this.music.isPlaying) {
       this.music.play();
     }
+  }
+
+  setMusicVolume(value) {
+    if (this.music) this.music.setVolume(value);
+  }
+
+  setSFXVolume(value) {
+    [this.plopSound, this.beeSound, this.waspSound].forEach((s) => {
+      if (s) s.setVolume(value);
+    });
+  }
+
+  setQuality(level) {
+    if (level === "low") {
+      this.pixelRatio = 0.5;
+      this.renderer.shadowMap.enabled = false;
+    } else {
+      this.pixelRatio = 1;
+      this.renderer.shadowMap.enabled = true;
+    }
+    this.renderer.setPixelRatio(this.pixelRatio);
   }
 
   // -----------------------------------

--- a/scss/components/_settings-menu.scss
+++ b/scss/components/_settings-menu.scss
@@ -1,0 +1,49 @@
+/* ----------------- COMPONENTE: Settings Menu ----------------- */
+.settings-button {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  z-index: 100;
+  background: var(--accent);
+  border: none;
+  color: #222;
+  font-size: 1rem;
+  padding: 6px 8px;
+  border-radius: 8px;
+}
+.settings-menu {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+  &.open {
+    display: flex;
+  }
+  .settings-content {
+    background: var(--dark-panel);
+    padding: 1rem;
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    color: var(--text-white);
+    min-width: 220px;
+    label {
+      display: flex;
+      flex-direction: column;
+      font-size: 0.8rem;
+      gap: 0.25rem;
+    }
+    .close-btn {
+      align-self: flex-end;
+      padding: 4px 8px;
+      background: var(--accent);
+      border: none;
+      border-radius: 6px;
+      color: #222;
+    }
+  }
+}

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -19,3 +19,4 @@
 @import "components/scene-container";
 @import "components/upgrade-bar";
 @import "components/upgrade-card";
+@import "components/settings-menu";


### PR DESCRIPTION
## Summary
- create SettingsMenu component
- add button and modal markup for configuration
- implement volume and quality controls in ThreeScene
- load SettingsMenu in App and compile new styles

## Testing
- `npm run build-css`

------
https://chatgpt.com/codex/tasks/task_e_68435d0c37148333b3019dfa1cfa9d33