### PR TITLE
Add achievement system

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -553,3 +553,85 @@ button:hover {
   border-radius: 6px;
   color: #222;
 }
+
+/* ----------------- COMPONENTE: Achievements Menu ----------------- */
+.achievements-button {
+  position: fixed;
+  top: 8px;
+  left: 50px;
+  z-index: 100;
+  background: var(--accent);
+  border: none;
+  color: #222;
+  font-size: 1rem;
+  padding: 6px 8px;
+  border-radius: 8px;
+}
+
+.achievements-menu {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+.achievements-menu.open {
+  display: flex;
+}
+.achievements-menu .achievements-content {
+  background: var(--dark-panel);
+  padding: 1rem;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  color: var(--text-white);
+  min-width: 220px;
+}
+.achievements-menu .achievement-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.achievements-menu .achievement-list li {
+  padding: 0.25rem 0;
+  border-bottom: 1px solid #444;
+}
+.achievements-menu .achievement-list li.unlocked {
+  color: var(--accent);
+}
+.achievements-menu .achievement-list li .desc {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--text-light);
+}
+.achievements-menu .close-btn {
+  align-self: flex-end;
+  padding: 4px 8px;
+  background: var(--accent);
+  border: none;
+  border-radius: 6px;
+  color: #222;
+}
+
+.achievement-toast {
+  position: fixed;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%) translateY(100%);
+  background: var(--dark-panel);
+  color: var(--text-white);
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  z-index: 300;
+}
+.achievement-toast.show {
+  transform: translateX(-50%) translateY(0);
+  opacity: 1;
+}

--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
         <canvas id="three-canvas"></canvas>
       </div>
       <button id="settings-button" class="settings-button">⚙</button>
+      <button id="achievements-button" class="achievements-button">🏆</button>
       <div class="settings-menu">
         <div class="settings-content">
           <h2>Settings</h2>
@@ -105,6 +106,13 @@
           <button id="settings-close" class="close-btn">Close</button>
         </div>
       </div>
+      <div class="achievements-menu">
+        <div class="achievements-content">
+          <h2>Achievements</h2>
+          <ul class="achievement-list"></ul>
+          <button id="achievements-close" class="close-btn">Close</button>
+        </div>
+      </div>
       <div class="upgrade-bar">
         <button class="upgrade-toggle" aria-expanded="false" aria-label="Show upgrades">
         </button>
@@ -122,6 +130,8 @@
   <script type="module" src="js/components/ResourceBar.js"></script>
   <script type="module" src="js/components/SoundToggle.js"></script>
   <script type="module" src="js/components/SettingsMenu.js"></script>
+  <script type="module" src="js/components/AchievementsMenu.js"></script>
+  <script type="module" src="js/config/achievements.js"></script>
   <script type="module" src="js/components/UpgradeCard.js"></script>
   <script type="module" src="js/config/upgrades.js"></script>
   <script type="module" src="js/components/UpgradeToggle.js"></script>

--- a/js/App.js
+++ b/js/App.js
@@ -6,11 +6,13 @@ import { IntroScreen } from "./components/IntroScreen.js";
 import { ResourceBar } from "./components/ResourceBar.js";
 import { SoundToggle } from "./components/SoundToggle.js";
 import { SettingsMenu } from "./components/SettingsMenu.js";
+import { AchievementsMenu } from "./components/AchievementsMenu.js";
 import { ThreeScene } from "./three/ThreeScene.js";
 import { GameManager } from "./GameManager.js";
 import { getElement } from "./utils/domHelper.js";
 import { UpgradeToggle } from "./components/UpgradeToggle.js";
 import { upgradeConfig } from "./config/upgrades.js";
+import { achievements } from "./config/achievements.js";
 import gsap from "https://esm.sh/gsap";
 /**
  * Clase principal que orquesta el flujo completo:
@@ -64,10 +66,12 @@ class App {
         this.resourceBar = new ResourceBar();
 
           // 6) Creamos SoundToggle (música)
-          this.soundToggle = new SoundToggle(this.threeScene.music);
+        this.soundToggle = new SoundToggle(this.threeScene.music);
 
           // 6b) Configuración de ajustes
           this.settingsMenu = new SettingsMenu(this.threeScene);
+          // 6c) Menú de logros
+          this.achievementsMenu = new AchievementsMenu(achievements);
 
         // 7) Contenedor donde se generarán las tarjetas
         this.upgradeContainer = getElement(".upgrade-bar .content-scroll");
@@ -79,6 +83,7 @@ class App {
           this.upgradeContainer,
           upgradeConfig,
           this.soundToggle,
+          this.achievementsMenu,
           { saveInterval: 30000 }
         );
 

--- a/js/GameManager.js
+++ b/js/GameManager.js
@@ -27,6 +27,7 @@ export class GameManager {
     upgradeContainer,
     upgradeDefs,
     soundToggle,
+    achievementsMenu = null,
     options = {}
   ) {
     this.threeScene = threeScene;
@@ -39,6 +40,7 @@ export class GameManager {
       this.upgradeOrder.push(cfg.type);
     });
     this.soundToggle = soundToggle;
+    this.achievementsMenu = achievementsMenu;
     this.upgradeCards = [];
 
     this.saveInterval = options.saveInterval || 30000;
@@ -336,6 +338,10 @@ export class GameManager {
       (c) => c.upgradeType === "mejorar-colmena"
     );
     if (hiveCard) hiveCard.refresh(hiveCost, this.hiveLevel * 5, canBuyHive);
+
+    if (this.achievementsMenu) {
+      this.achievementsMenu.check(this.getState());
+    }
   }
 
   // -------------------------------------------------

--- a/js/components/AchievementsMenu.js
+++ b/js/components/AchievementsMenu.js
@@ -1,0 +1,100 @@
+// js/components/AchievementsMenu.js
+import { getElement, createElement } from "../utils/domHelper.js";
+
+export class AchievementsMenu {
+  constructor(achievements) {
+    this.achievements = achievements;
+    this.menuEl = getElement(".achievements-menu");
+    this.openBtn = getElement("#achievements-button");
+    this.closeBtn = getElement("#achievements-close");
+    this.listEl = this.menuEl.querySelector(".achievement-list");
+    this.unlocked = new Set(
+      JSON.parse(localStorage.getItem("honeyHiveAchievements") || "[]")
+    );
+
+    this.openBtn.addEventListener("click", () =>
+      this.menuEl.classList.add("open")
+    );
+    this.closeBtn.addEventListener("click", () =>
+      this.menuEl.classList.remove("open")
+    );
+
+    this.achievements.forEach((a) => {
+      const li = createElement(
+        "li",
+        { "data-id": a.id },
+        this.listEl
+      );
+      createElement("span", { className: "title", textContent: a.title }, li);
+      createElement(
+        "span",
+        { className: "desc", textContent: a.description },
+        li
+      );
+      if (this.unlocked.has(a.id)) li.classList.add("unlocked");
+    });
+  }
+
+  _save() {
+    localStorage.setItem(
+      "honeyHiveAchievements",
+      JSON.stringify([...this.unlocked])
+    );
+  }
+
+  _showToast(title) {
+    const toast = createElement(
+      "div",
+      { className: "achievement-toast", textContent: `Achievement Unlocked: ${title}!` },
+      document.body
+    );
+    requestAnimationFrame(() => toast.classList.add("show"));
+    setTimeout(() => {
+      toast.classList.remove("show");
+      toast.addEventListener("transitionend", () => toast.remove());
+    }, 3000);
+  }
+
+  check(state) {
+    this.achievements.forEach((a) => {
+      if (this.unlocked.has(a.id)) return;
+      let ok = false;
+      switch (a.type) {
+        case "bees":
+          ok = state.bees >= a.value;
+          break;
+        case "wasps":
+          ok = state.wasps >= a.value;
+          break;
+        case "ducks":
+          ok = state.ducks >= a.value;
+          break;
+        case "userLevel":
+          ok = state.userLevel >= a.value;
+          break;
+        case "prodLevel":
+          ok = state.prodLevel >= a.value;
+          break;
+        case "hiveLevel":
+          ok = state.hiveLevel >= a.value;
+          break;
+        case "pollenLifetime":
+          ok = state.pollenLifetime >= a.value;
+          break;
+        case "pollen":
+          ok = state.pollen >= a.value;
+          break;
+        case "nectar":
+          ok = state.nectar >= a.value;
+          break;
+      }
+      if (ok) {
+        this.unlocked.add(a.id);
+        const li = this.listEl.querySelector(`li[data-id="${a.id}"]`);
+        if (li) li.classList.add("unlocked");
+        this._save();
+        this._showToast(a.title);
+      }
+    });
+  }
+}

--- a/js/config/achievements.js
+++ b/js/config/achievements.js
@@ -1,0 +1,22 @@
+export const achievements = [
+  { id: 'bee-1', title: 'First Bee', description: 'Hire your first bee', type: 'bees', value: 1 },
+  { id: 'bee-20', title: 'Bee Fanatic', description: 'Reach 20 bees', type: 'bees', value: 20 },
+  { id: 'bee-50', title: 'Busy Hive', description: 'Reach 50 bees', type: 'bees', value: 50 },
+  { id: 'wasp-1', title: 'Wasp Wrangler', description: 'Hire your first wasp', type: 'wasps', value: 1 },
+  { id: 'wasp-5', title: 'Wasp Army', description: 'Hire 5 wasps', type: 'wasps', value: 5 },
+  { id: 'duck-1', title: 'Duck Tamer', description: 'Hire your first duck', type: 'ducks', value: 1 },
+  { id: 'duck-3', title: 'Duck Squad', description: 'Hire 3 ducks', type: 'ducks', value: 3 },
+  { id: 'prod-1', title: 'First Upgrade', description: 'Buy a production upgrade', type: 'prodLevel', value: 1 },
+  { id: 'prod-5', title: 'Efficient Worker', description: 'Reach production level 5', type: 'prodLevel', value: 5 },
+  { id: 'hive-1', title: 'Hive Builder', description: 'Upgrade your hive', type: 'hiveLevel', value: 1 },
+  { id: 'hive-5', title: 'Master Hive', description: 'Reach hive level 5', type: 'hiveLevel', value: 5 },
+  { id: 'level-2', title: 'First Level Up', description: 'Reach user level 2', type: 'userLevel', value: 2 },
+  { id: 'level-5', title: 'Experienced Player', description: 'Reach user level 5', type: 'userLevel', value: 5 },
+  { id: 'level-10', title: 'Pro Gamer', description: 'Reach user level 10', type: 'userLevel', value: 10 },
+  { id: 'pollen-100', title: 'Apprentice Harvester', description: 'Accumulate 100 pollen', type: 'pollen', value: 100 },
+  { id: 'pollenlife-1000', title: 'Pollen Hoarder', description: 'Collect 1,000 total pollen', type: 'pollenLifetime', value: 1000 },
+  { id: 'pollenlife-50000', title: 'Pollen Tycoon', description: 'Collect 50,000 total pollen', type: 'pollenLifetime', value: 50000 },
+  { id: 'pollenlife-1000000', title: 'Millionaire', description: 'Collect 1,000,000 total pollen', type: 'pollenLifetime', value: 1000000 },
+  { id: 'nectar-1000', title: 'Sweet Nectar', description: 'Collect 1,000 nectar', type: 'nectar', value: 1000 },
+  { id: 'nectar-5000', title: 'Nectar Overflow', description: 'Collect 5,000 nectar', type: 'nectar', value: 5000 }
+];

--- a/scss/components/_achievements-menu.scss
+++ b/scss/components/_achievements-menu.scss
@@ -1,0 +1,81 @@
+/* ----------------- COMPONENTE: Achievements Menu ----------------- */
+.achievements-button {
+  position: fixed;
+  top: 8px;
+  left: 50px;
+  z-index: 100;
+  background: var(--accent);
+  border: none;
+  color: #222;
+  font-size: 1rem;
+  padding: 6px 8px;
+  border-radius: 8px;
+}
+
+.achievements-menu {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+  &.open {
+    display: flex;
+  }
+  .achievements-content {
+    background: var(--dark-panel);
+    padding: 1rem;
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    color: var(--text-white);
+    min-width: 220px;
+  }
+  .achievement-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    max-height: 200px;
+    overflow-y: auto;
+    li {
+      padding: 0.25rem 0;
+      border-bottom: 1px solid #444;
+      &.unlocked {
+        color: var(--accent);
+      }
+      .desc {
+        display: block;
+        font-size: 0.75rem;
+        color: var(--text-light);
+      }
+    }
+  }
+  .close-btn {
+    align-self: flex-end;
+    padding: 4px 8px;
+    background: var(--accent);
+    border: none;
+    border-radius: 6px;
+    color: #222;
+  }
+}
+
+.achievement-toast {
+  position: fixed;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%) translateY(100%);
+  background: var(--dark-panel);
+  color: var(--text-white);
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  z-index: 300;
+  &.show {
+    transform: translateX(-50%) translateY(0);
+    opacity: 1;
+  }
+}

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -20,3 +20,4 @@
 @import "components/upgrade-bar";
 @import "components/upgrade-card";
 @import "components/settings-menu";
+@import "components/achievements-menu";


### PR DESCRIPTION
## Summary
- track player progress with new Achievement menu
- list 20 unlockable achievements
- show menu with new trophy button and toast notifications
- wire achievements into GameManager and App initialization
- include fresh CSS build

## Testing
- `npm install`
- `npm run build-css`

------
https://chatgpt.com/codex/tasks/task_e_6843a0de4300833380ccb4be7cb748c2