### PR TITLE
Add random wasp minigame event

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -618,6 +618,44 @@ button:hover {
   color: #222;
 }
 
+/* ----------------- COMPONENTE: Minigame ----------------- */
+.minigame-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+.minigame-overlay.active {
+  display: flex;
+}
+.minigame-area {
+  position: relative;
+  width: 80vw;
+  height: 60vh;
+  background: var(--dark-panel);
+  border-radius: 12px;
+  overflow: hidden;
+  color: var(--text-white);
+}
+.minigame-info {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  font-size: 0.8rem;
+}
+.wasp-target {
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  background-image: url("../assets/images/icon-wasp.png");
+  background-size: contain;
+  background-repeat: no-repeat;
+  cursor: pointer;
+}
+
 .achievement-toast {
   position: fixed;
   bottom: 10px;

--- a/index.html
+++ b/index.html
@@ -113,6 +113,11 @@
           <button id="achievements-close" class="close-btn">Close</button>
         </div>
       </div>
+      <div class="minigame-overlay">
+        <div class="minigame-area">
+          <div class="minigame-info">Time: <span id="minigame-timer">15</span> | Score: <span id="minigame-score">0</span></div>
+        </div>
+      </div>
       <div class="upgrade-bar">
         <button class="upgrade-toggle" aria-expanded="false" aria-label="Show upgrades">
         </button>
@@ -135,6 +140,7 @@
   <script type="module" src="js/components/UpgradeCard.js"></script>
   <script type="module" src="js/config/upgrades.js"></script>
   <script type="module" src="js/components/UpgradeToggle.js"></script>
+  <script type="module" src="js/minigames/WaspMiniGame.js"></script>
   <script type="module" src="js/three/ThreeScene.js"></script>
   <script type="module" src="js/GameManager.js"></script>
   <script type="module" src="js/App.js"></script>

--- a/js/App.js
+++ b/js/App.js
@@ -13,6 +13,7 @@ import { getElement } from "./utils/domHelper.js";
 import { UpgradeToggle } from "./components/UpgradeToggle.js";
 import { upgradeConfig } from "./config/upgrades.js";
 import { achievements } from "./config/achievements.js";
+import { WaspMiniGame } from "./minigames/WaspMiniGame.js";
 import gsap from "https://esm.sh/gsap";
 /**
  * Clase principal que orquesta el flujo completo:
@@ -69,9 +70,12 @@ class App {
         this.soundToggle = new SoundToggle(this.threeScene.music);
 
           // 6b) Configuración de ajustes
-          this.settingsMenu = new SettingsMenu(this.threeScene);
-          // 6c) Menú de logros
-          this.achievementsMenu = new AchievementsMenu(achievements);
+        this.settingsMenu = new SettingsMenu(this.threeScene);
+        // 6c) Menú de logros
+        this.achievementsMenu = new AchievementsMenu(achievements);
+        this.waspMiniGame = new WaspMiniGame((score) =>
+          this.gameManager.endMiniGame(score)
+        );
 
         // 7) Contenedor donde se generarán las tarjetas
         this.upgradeContainer = getElement(".upgrade-bar .content-scroll");
@@ -84,6 +88,7 @@ class App {
           upgradeConfig,
           this.soundToggle,
           this.achievementsMenu,
+          this.waspMiniGame,
           { saveInterval: 30000 }
         );
 

--- a/js/minigames/WaspMiniGame.js
+++ b/js/minigames/WaspMiniGame.js
@@ -1,0 +1,62 @@
+import { getElement } from "../utils/domHelper.js";
+
+export class WaspMiniGame {
+  constructor(onEnd) {
+    this.overlay = getElement(".minigame-overlay");
+    this.area = this.overlay.querySelector(".minigame-area");
+    this.timerEl = this.overlay.querySelector("#minigame-timer");
+    this.scoreEl = this.overlay.querySelector("#minigame-score");
+    this.onEnd = onEnd;
+    this.duration = 15;
+    this.active = false;
+    this._timer = null;
+    this._spawnTimer = null;
+  }
+
+  start() {
+    if (this.active) return;
+    this.active = true;
+    this.remaining = this.duration;
+    this.score = 0;
+    this._updateUI();
+    this.area.innerHTML = "";
+    this.overlay.classList.add("active");
+    this._timer = setInterval(() => {
+      this.remaining--;
+      this._updateUI();
+      if (this.remaining <= 0) this.end();
+    }, 1000);
+    this._spawnTimer = setInterval(() => this._spawnWasp(), 700);
+  }
+
+  _spawnWasp() {
+    const el = document.createElement("div");
+    el.className = "wasp-target";
+    const maxX = this.area.clientWidth - 40;
+    const maxY = this.area.clientHeight - 40;
+    el.style.left = Math.random() * maxX + "px";
+    el.style.top = Math.random() * maxY + "px";
+    el.addEventListener("click", () => {
+      el.remove();
+      this.score++;
+      this.scoreEl.textContent = this.score;
+    });
+    setTimeout(() => el.remove(), 1500);
+    this.area.appendChild(el);
+  }
+
+  _updateUI() {
+    this.timerEl.textContent = this.remaining;
+    this.scoreEl.textContent = this.score;
+  }
+
+  end() {
+    if (!this.active) return;
+    clearInterval(this._timer);
+    clearInterval(this._spawnTimer);
+    this.overlay.classList.remove("active");
+    this.area.innerHTML = "";
+    this.active = false;
+    if (this.onEnd) this.onEnd(this.score);
+  }
+}

--- a/js/three/ThreeScene.js
+++ b/js/three/ThreeScene.js
@@ -876,6 +876,37 @@ _moveInOrbit(entity, delta, hiveCenter) {
     });
   }
 
+  // Animar cámara hacia la zona del minijuego
+  moveToMiniGame() {
+    gsap.to(this.camera.position, {
+      x: -4,
+      y: 1.5,
+      z: 0,
+      ease: "power2.out",
+      duration: 4,
+    });
+    gsap.to(this.camera.rotation, {
+      x: 0,
+      y: -Math.PI / 2,
+      z: 0,
+      ease: "power2.out",
+      duration: 4,
+    });
+    gsap.to(this.camera, {
+      zoom: 1.4,
+      ease: "power2.out",
+      duration: 4,
+      onUpdate: () => this.camera.updateProjectionMatrix(),
+      onComplete: () => {
+        this.controls.maxDistance = 5;
+      },
+    });
+  }
+
+  returnFromMiniGame() {
+    this.playGameAnimation();
+  }
+
   // -----------------------------------
   // 21. Ajustar tamaño al cambiar ventana
   // -----------------------------------


### PR DESCRIPTION
## Summary
- add WaspMiniGame class with simple click-to-remove gameplay
- create overlay and styles for the minigame
- add camera animations to move into and out of the minigame
- integrate random event logic in GameManager
- hook up the minigame from App

## Testing
- `npm run build-css` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844568a65308333b5d017291ae06d46