### PR TITLE
Add modular Three.js post-processing pipeline

### DIFF
--- a/js/three/ThreeScene.js
+++ b/js/three/ThreeScene.js
@@ -3,11 +3,7 @@
 import * as THREE from "https://esm.sh/three@0.174.0";
 import { OrbitControls } from "https://esm.sh/three@0.174.0/examples/jsm/controls/OrbitControls.js";
 import * as SkeletonUtils from "https://esm.sh/three@0.174.0/examples/jsm/utils/SkeletonUtils.js";
-import { EffectComposer } from "https://esm.sh/three@0.174.0/examples/jsm/postprocessing/EffectComposer.js";
-import { RenderPass } from "https://esm.sh/three@0.174.0/examples/jsm/postprocessing/RenderPass.js";
-import { BokehPass } from "https://esm.sh/three@0.174.0/examples/jsm/postprocessing/BokehPass.js";
-import { ShaderPass } from "https://esm.sh/three@0.174.0/examples/jsm/postprocessing/ShaderPass.js";
-import { GammaCorrectionShader } from "https://esm.sh/three@0.174.0/examples/jsm/shaders/GammaCorrectionShader.js";
+import { PostProcessingManager } from "./postprocessing/PostProcessingManager.js";
 import { PMREMGenerator, HalfFloatType } from "https://esm.sh/three@0.174.0";
 
 import Stats from "https://esm.sh/stats.js@0.17.0";
@@ -140,25 +136,14 @@ export class ThreeScene {
   }
 
   // -----------------------------------
-  // 4. Post-processing (RenderPass, Bokeh, Gamma)
+  // 4. Modular post-processing pipeline
   // -----------------------------------
   _initPostProcessing() {
-    this.composer = new EffectComposer(this.renderer);
-    const renderPass = new RenderPass(this.scene, this.camera);
-    this.composer.addPass(renderPass);
-
-    const bokehParams = {
-      focus: 3,
-      aperture: 0.001,
-      maxblur: 0.01,
-      width: this.containerEl.clientWidth,
-      height: this.containerEl.clientHeight,
-    };
-    const bokehPass = new BokehPass(this.scene, this.camera, bokehParams);
-    this.composer.addPass(bokehPass);
-
-    const gammaPass = new ShaderPass(GammaCorrectionShader);
-    this.composer.addPass(gammaPass);
+    this.rendererEffects = new PostProcessingManager(
+      this.renderer,
+      this.scene,
+      this.camera
+    );
   }
 
   // -----------------------------------
@@ -213,6 +198,13 @@ export class ThreeScene {
       this.renderer.shadowMap.enabled = true;
     }
     this.renderer.setPixelRatio(this.pixelRatio);
+    if (this.rendererEffects) {
+      this.rendererEffects.resize(
+        this.containerEl.clientWidth,
+        this.containerEl.clientHeight,
+        this.pixelRatio
+      );
+    }
   }
 
   // -----------------------------------
@@ -927,9 +919,8 @@ _moveInOrbit(entity, delta, hiveCenter) {
       //this.stats.update();
       this.controls.update();
 
-      // Renderizar escena y post-proceso
-      this.renderer.render(this.scene, this.camera);
-      this.composer.render();
+      // Renderizar escena con el pipeline modular de post-proceso.
+      this.rendererEffects.render(delta);
     };
 
     renderFrame();
@@ -969,10 +960,10 @@ _moveInOrbit(entity, delta, hiveCenter) {
   // 21. Ajustar tamaño al cambiar ventana
   // -----------------------------------
   _onResize() {
-    const w = window.innerWidth;
-    const h = window.innerHeight;
+    const w = this.containerEl.clientWidth || window.innerWidth;
+    const h = this.containerEl.clientHeight || window.innerHeight;
     this.camera.aspect = w / h;
     this.camera.updateProjectionMatrix();
-    this.renderer.setSize(w, h, false);
+    this.rendererEffects.resize(w, h, this.pixelRatio);
   }
 }

--- a/js/three/postprocessing/PostProcessingConfig.js
+++ b/js/three/postprocessing/PostProcessingConfig.js
@@ -1,0 +1,68 @@
+export const POST_PROCESSING_DEFAULTS = Object.freeze({
+  mode: "default",
+  pixelRatio: Math.min(globalThis.devicePixelRatio || 1, 2),
+  renderToScreen: true,
+  toon: {
+    enabled: false,
+    outline: true,
+    outlineThickness: 0.003,
+    outlineColor: "#000000",
+    quantization: true,
+    colorLevels: 5,
+  },
+  crt: {
+    enabled: false,
+    scanlines: 0.45,
+    curvature: 0.18,
+    chromaticAberration: 0.0025,
+    grain: 0.14,
+    noise: 0.08,
+    flicker: 0.04,
+    barrelDistortion: 0.08,
+    vignette: 0.35,
+  },
+  bloom: {
+    enabled: false,
+    threshold: 0.82,
+    strength: 0.55,
+    radius: 0.35,
+  },
+  colorGrading: {
+    enabled: true,
+    saturation: 1,
+    contrast: 1,
+    brightness: 0,
+    gamma: 1,
+    exposure: 1,
+  },
+  film: {
+    enabled: false,
+    noiseIntensity: 0.35,
+    scanlineIntensity: 0.12,
+    grayscale: false,
+  },
+  pixelation: {
+    enabled: false,
+    pixelSize: 4,
+  },
+});
+
+export const POST_PROCESSING_MODES = Object.freeze({
+  default: {},
+  comic: {
+    toon: { enabled: true, outline: true, quantization: true },
+    crt: { enabled: false },
+    film: { enabled: false },
+    pixelation: { enabled: false },
+  },
+  crt: {
+    crt: { enabled: true },
+    film: { enabled: true, noiseIntensity: 0.18, scanlineIntensity: 0.08 },
+    toon: { enabled: false },
+    pixelation: { enabled: false },
+  },
+  pixel: {
+    pixelation: { enabled: true },
+    toon: { enabled: false },
+  },
+});

--- a/js/three/postprocessing/PostProcessingManager.js
+++ b/js/three/postprocessing/PostProcessingManager.js
@@ -1,0 +1,205 @@
+import * as THREE from "https://esm.sh/three@0.174.0";
+import { EffectComposer } from "https://esm.sh/three@0.174.0/examples/jsm/postprocessing/EffectComposer.js";
+import { RenderPass } from "https://esm.sh/three@0.174.0/examples/jsm/postprocessing/RenderPass.js";
+import { ShaderPass } from "https://esm.sh/three@0.174.0/examples/jsm/postprocessing/ShaderPass.js";
+import { UnrealBloomPass } from "https://esm.sh/three@0.174.0/examples/jsm/postprocessing/UnrealBloomPass.js";
+import { OutlinePass } from "https://esm.sh/three@0.174.0/examples/jsm/postprocessing/OutlinePass.js";
+import { GammaCorrectionShader } from "https://esm.sh/three@0.174.0/examples/jsm/shaders/GammaCorrectionShader.js";
+
+import { POST_PROCESSING_DEFAULTS, POST_PROCESSING_MODES } from "./PostProcessingConfig.js";
+import { ToonShader } from "./shaders/ToonShader.js";
+import { CRTShader } from "./shaders/CRTShader.js";
+import { ColorGradingShader } from "./shaders/ColorGradingShader.js";
+import { PixelationShader } from "./shaders/PixelationShader.js";
+import { FilmGrainShader } from "./shaders/FilmGrainShader.js";
+
+const deepMerge = (target, source = {}) => {
+  for (const [key, value] of Object.entries(source)) {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      target[key] = deepMerge({ ...(target[key] || {}) }, value);
+    } else {
+      target[key] = value;
+    }
+  }
+  return target;
+};
+
+/**
+ * Owns the complete post-processing stack for the Three.js scene.
+ *
+ * Passes are created once and toggled with `enabled` flags so runtime mode
+ * changes avoid GPU allocation churn. Disabled passes are skipped by
+ * EffectComposer, keeping the frame path as small as possible.
+ */
+export class PostProcessingManager {
+  constructor(renderer, scene, camera, config = {}) {
+    this.renderer = renderer;
+    this.scene = scene;
+    this.camera = camera;
+    this.clock = new THREE.Clock();
+    this.size = new THREE.Vector2();
+    this.resolution = new THREE.Vector2(1, 1);
+    this.outlineColor = new THREE.Color();
+    this.config = deepMerge(this._cloneDefaults(), config);
+
+    this.composer = new EffectComposer(renderer);
+    this.composer.renderToScreen = this.config.renderToScreen;
+
+    this._createPasses();
+    this._addPassesInDisplayOrder();
+    this.resize();
+    this.applyConfig();
+  }
+
+  _cloneDefaults() {
+    return JSON.parse(JSON.stringify(POST_PROCESSING_DEFAULTS));
+  }
+
+  _createPasses() {
+    // Required base pass: renders the scene once into the composer buffer.
+    this.renderPass = new RenderPass(this.scene, this.camera);
+
+    // Object outlines provide the comic ink stroke around meshes. We select all
+    // scene meshes each render so dynamically spawned bees/wasps are included.
+    this.outlinePass = new OutlinePass(this.resolution, this.scene, this.camera);
+    this.outlinePass.pulsePeriod = 0;
+    this.outlinePass.usePatternTexture = false;
+
+    // Screen-space color quantization creates a lightweight cel-shaded palette
+    // without replacing materials on gameplay assets.
+    this.toonPass = new ShaderPass(ToonShader);
+
+    // UnrealBloomPass is Three's modern bloom implementation for thresholded
+    // emissive/highlight glow.
+    this.bloomPass = new UnrealBloomPass(this.resolution, 0.55, 0.35, 0.82);
+
+    // Color grading is intentionally one small shader: saturation, contrast,
+    // brightness, gamma and exposure are adjusted in a single pass.
+    this.colorGradingPass = new ShaderPass(ColorGradingShader);
+
+    // Custom film shader supplies classic grain and scanline treatment with an
+    // optional grayscale switch.
+    this.filmPass = new ShaderPass(FilmGrainShader);
+
+    // CRT pass combines curvature, aberration, distortion, scanlines, vignette
+    // and flicker so CRT mode costs one extra full-screen draw.
+    this.crtPass = new ShaderPass(CRTShader);
+    this.crtPass.uniforms.resolution.value = this.resolution;
+
+    // Pixelation happens after scene effects. DOM UI is not inside this canvas,
+    // so the game's HTML HUD remains sharp while the 3D world is pixelated.
+    this.pixelationPass = new ShaderPass(PixelationShader);
+    this.pixelationPass.uniforms.resolution.value = this.resolution;
+
+    // Keep gamma last so custom shaders can work in linear-ish color values and
+    // the final canvas is corrected consistently.
+    this.gammaPass = new ShaderPass(GammaCorrectionShader);
+  }
+
+  _addPassesInDisplayOrder() {
+    [
+      this.renderPass,
+      this.outlinePass,
+      this.toonPass,
+      this.bloomPass,
+      this.colorGradingPass,
+      this.filmPass,
+      this.crtPass,
+      this.pixelationPass,
+      this.gammaPass,
+    ].forEach((pass) => this.composer.addPass(pass));
+  }
+
+  setMode(modeName) {
+    if (!POST_PROCESSING_MODES[modeName]) {
+      console.warn(`Unknown post-processing mode: ${modeName}`);
+      return;
+    }
+    this.config.mode = modeName;
+    this.update(POST_PROCESSING_MODES[modeName]);
+  }
+
+  enableBloom(enabled) {
+    this.update({ bloom: { enabled } });
+  }
+
+  enablePixelation(enabled) {
+    this.update({ pixelation: { enabled } });
+  }
+
+  update(partialConfig = {}) {
+    this.config = deepMerge(this.config, partialConfig);
+    this.applyConfig();
+  }
+
+  applyConfig() {
+    const { toon, crt, bloom, colorGrading, film, pixelation } = this.config;
+
+    this.outlinePass.enabled = Boolean(toon.enabled && toon.outline);
+    this.outlinePass.edgeStrength = 4;
+    this.outlinePass.edgeGlow = 0;
+    this.outlinePass.edgeThickness = Math.max(0.001, toon.outlineThickness * 1000);
+    this.outlineColor.set(toon.outlineColor);
+    this.outlinePass.visibleEdgeColor.copy(this.outlineColor);
+    this.outlinePass.hiddenEdgeColor.copy(this.outlineColor);
+
+    this.toonPass.enabled = Boolean(toon.enabled && toon.quantization);
+    this.toonPass.uniforms.enabled.value = toon.enabled ? 1 : 0;
+    this.toonPass.uniforms.quantization.value = toon.quantization ? 1 : 0;
+    this.toonPass.uniforms.colorLevels.value = toon.colorLevels;
+
+    this.bloomPass.enabled = Boolean(bloom.enabled);
+    this.bloomPass.threshold = bloom.threshold;
+    this.bloomPass.strength = bloom.strength;
+    this.bloomPass.radius = bloom.radius;
+
+    this.colorGradingPass.enabled = Boolean(colorGrading.enabled);
+    this.colorGradingPass.uniforms.saturation.value = colorGrading.saturation;
+    this.colorGradingPass.uniforms.contrast.value = colorGrading.contrast;
+    this.colorGradingPass.uniforms.brightness.value = colorGrading.brightness;
+    this.colorGradingPass.uniforms.gamma.value = colorGrading.gamma;
+    this.colorGradingPass.uniforms.exposure.value = colorGrading.exposure;
+
+    this.filmPass.enabled = Boolean(film.enabled);
+    this.filmPass.uniforms.noiseIntensity.value = film.noiseIntensity;
+    this.filmPass.uniforms.scanlineIntensity.value = film.scanlineIntensity;
+    this.filmPass.uniforms.grayscale.value = film.grayscale;
+
+    this.crtPass.enabled = Boolean(crt.enabled);
+    Object.entries(crt).forEach(([key, value]) => {
+      if (this.crtPass.uniforms[key]) this.crtPass.uniforms[key].value = value;
+    });
+
+    this.pixelationPass.enabled = Boolean(pixelation.enabled);
+    this.pixelationPass.uniforms.pixelSize.value = pixelation.pixelSize;
+  }
+
+  resize(width, height, pixelRatio = this.config.pixelRatio) {
+    this.renderer.getSize(this.size);
+    const displayWidth = width ?? this.size.x;
+    const displayHeight = height ?? this.size.y;
+    const ratio = Math.min(pixelRatio || 1, 2);
+    this.config.pixelRatio = ratio;
+    this.renderer.setPixelRatio(ratio);
+    this.renderer.setSize(displayWidth, displayHeight, false);
+    this.resolution.set(Math.max(1, displayWidth * ratio), Math.max(1, displayHeight * ratio));
+    this.composer.setPixelRatio(ratio);
+    this.composer.setSize(displayWidth, displayHeight);
+    this.outlinePass.setSize(displayWidth, displayHeight);
+  }
+
+  render(deltaTime = this.clock.getDelta()) {
+    if (this.outlinePass.enabled) this._refreshOutlinedObjects();
+    if (this.filmPass.enabled) this.filmPass.uniforms.time.value += deltaTime;
+    if (this.crtPass.enabled) this.crtPass.uniforms.time.value += deltaTime;
+    this.composer.render(deltaTime);
+  }
+
+  _refreshOutlinedObjects() {
+    const selectedObjects = this.outlinePass.selectedObjects;
+    selectedObjects.length = 0;
+    this.scene.traverse((object) => {
+      if (object.isMesh && object.visible) selectedObjects.push(object);
+    });
+  }
+}

--- a/js/three/postprocessing/shaders/CRTShader.js
+++ b/js/three/postprocessing/shaders/CRTShader.js
@@ -1,0 +1,76 @@
+export const CRTShader = {
+  name: "HoneyHiveCRTShader",
+  uniforms: {
+    tDiffuse: { value: null },
+    resolution: { value: null },
+    time: { value: 0 },
+    scanlines: { value: 0.45 },
+    curvature: { value: 0.18 },
+    chromaticAberration: { value: 0.0025 },
+    grain: { value: 0.14 },
+    noise: { value: 0.08 },
+    flicker: { value: 0.04 },
+    barrelDistortion: { value: 0.08 },
+    vignette: { value: 0.35 },
+  },
+  vertexShader: /* glsl */`
+    varying vec2 vUv;
+    void main() {
+      vUv = uv;
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+  `,
+  fragmentShader: /* glsl */`
+    uniform sampler2D tDiffuse;
+    uniform vec2 resolution;
+    uniform float time;
+    uniform float scanlines;
+    uniform float curvature;
+    uniform float chromaticAberration;
+    uniform float grain;
+    uniform float noise;
+    uniform float flicker;
+    uniform float barrelDistortion;
+    uniform float vignette;
+    varying vec2 vUv;
+
+    float random(vec2 p) {
+      return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
+    }
+
+    vec2 distort(vec2 uv) {
+      vec2 centered = uv * 2.0 - 1.0;
+      float r2 = dot(centered, centered);
+      centered *= 1.0 + r2 * barrelDistortion;
+      centered.x *= 1.0 + curvature * centered.y * centered.y;
+      centered.y *= 1.0 + curvature * centered.x * centered.x;
+      return centered * 0.5 + 0.5;
+    }
+
+    void main() {
+      vec2 uv = distort(vUv);
+      if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
+        gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+        return;
+      }
+
+      vec2 aberration = vec2(chromaticAberration, 0.0);
+      float r = texture2D(tDiffuse, uv + aberration).r;
+      float g = texture2D(tDiffuse, uv).g;
+      float b = texture2D(tDiffuse, uv - aberration).b;
+      vec3 color = vec3(r, g, b);
+
+      float line = sin(uv.y * resolution.y * 3.14159);
+      color *= 1.0 - scanlines * (0.5 + 0.5 * line) * 0.45;
+
+      float n = random(uv * resolution.xy + time * 37.0);
+      color += (n - 0.5) * noise;
+      color = mix(color, color * (0.85 + n * 0.3), grain);
+      color *= 1.0 + sin(time * 38.0) * flicker;
+
+      vec2 d = uv - 0.5;
+      color *= 1.0 - smoothstep(0.25, 0.82, dot(d, d) * 2.0) * vignette;
+      gl_FragColor = vec4(color, 1.0);
+    }
+  `,
+};

--- a/js/three/postprocessing/shaders/ColorGradingShader.js
+++ b/js/three/postprocessing/shaders/ColorGradingShader.js
@@ -1,0 +1,38 @@
+export const ColorGradingShader = {
+  name: "HoneyHiveColorGradingShader",
+  uniforms: {
+    tDiffuse: { value: null },
+    saturation: { value: 1 },
+    contrast: { value: 1 },
+    brightness: { value: 0 },
+    gamma: { value: 1 },
+    exposure: { value: 1 },
+  },
+  vertexShader: /* glsl */`
+    varying vec2 vUv;
+    void main() {
+      vUv = uv;
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+  `,
+  fragmentShader: /* glsl */`
+    uniform sampler2D tDiffuse;
+    uniform float saturation;
+    uniform float contrast;
+    uniform float brightness;
+    uniform float gamma;
+    uniform float exposure;
+    varying vec2 vUv;
+
+    void main() {
+      vec4 color = texture2D(tDiffuse, vUv);
+      color.rgb *= exposure;
+      float luminance = dot(color.rgb, vec3(0.2126, 0.7152, 0.0722));
+      color.rgb = mix(vec3(luminance), color.rgb, saturation);
+      color.rgb = (color.rgb - 0.5) * contrast + 0.5;
+      color.rgb += brightness;
+      color.rgb = pow(max(color.rgb, vec3(0.0)), vec3(1.0 / max(gamma, 0.0001)));
+      gl_FragColor = color;
+    }
+  `,
+};

--- a/js/three/postprocessing/shaders/FilmGrainShader.js
+++ b/js/three/postprocessing/shaders/FilmGrainShader.js
@@ -1,0 +1,44 @@
+export const FilmGrainShader = {
+  name: "HoneyHiveFilmGrainShader",
+  uniforms: {
+    tDiffuse: { value: null },
+    time: { value: 0 },
+    noiseIntensity: { value: 0.35 },
+    scanlineIntensity: { value: 0.12 },
+    grayscale: { value: false },
+  },
+  vertexShader: /* glsl */`
+    varying vec2 vUv;
+    void main() {
+      vUv = uv;
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+  `,
+  fragmentShader: /* glsl */`
+    uniform sampler2D tDiffuse;
+    uniform float time;
+    uniform float noiseIntensity;
+    uniform float scanlineIntensity;
+    uniform bool grayscale;
+    varying vec2 vUv;
+
+    float random(vec2 p) {
+      return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
+    }
+
+    void main() {
+      vec4 base = texture2D(tDiffuse, vUv);
+      float grain = random(vUv + time * 0.01) - 0.5;
+      float scanline = sin(vUv.y * 900.0) * 0.5 + 0.5;
+      vec3 color = base.rgb + grain * noiseIntensity;
+      color *= 1.0 - scanline * scanlineIntensity;
+
+      if (grayscale) {
+        float luma = dot(color, vec3(0.2126, 0.7152, 0.0722));
+        color = vec3(luma);
+      }
+
+      gl_FragColor = vec4(color, base.a);
+    }
+  `,
+};

--- a/js/three/postprocessing/shaders/PixelationShader.js
+++ b/js/three/postprocessing/shaders/PixelationShader.js
@@ -1,0 +1,27 @@
+export const PixelationShader = {
+  name: "HoneyHivePixelationShader",
+  uniforms: {
+    tDiffuse: { value: null },
+    resolution: { value: null },
+    pixelSize: { value: 4 },
+  },
+  vertexShader: /* glsl */`
+    varying vec2 vUv;
+    void main() {
+      vUv = uv;
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+  `,
+  fragmentShader: /* glsl */`
+    uniform sampler2D tDiffuse;
+    uniform vec2 resolution;
+    uniform float pixelSize;
+    varying vec2 vUv;
+
+    void main() {
+      vec2 pixels = max(resolution / max(pixelSize, 1.0), vec2(1.0));
+      vec2 uv = (floor(vUv * pixels) + 0.5) / pixels;
+      gl_FragColor = texture2D(tDiffuse, uv);
+    }
+  `,
+};

--- a/js/three/postprocessing/shaders/ToonShader.js
+++ b/js/three/postprocessing/shaders/ToonShader.js
@@ -1,0 +1,38 @@
+export const ToonShader = {
+  name: "HoneyHiveToonShader",
+  uniforms: {
+    tDiffuse: { value: null },
+    enabled: { value: 0 },
+    quantization: { value: 1 },
+    colorLevels: { value: 5 },
+  },
+  vertexShader: /* glsl */`
+    varying vec2 vUv;
+    void main() {
+      vUv = uv;
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+  `,
+  fragmentShader: /* glsl */`
+    uniform sampler2D tDiffuse;
+    uniform float enabled;
+    uniform float quantization;
+    uniform float colorLevels;
+    varying vec2 vUv;
+
+    void main() {
+      vec4 color = texture2D(tDiffuse, vUv);
+      if (enabled < 0.5 || quantization < 0.5) {
+        gl_FragColor = color;
+        return;
+      }
+
+      float levels = max(colorLevels, 2.0);
+      vec3 quantized = floor(color.rgb * levels) / levels;
+      // Keep a small blend with the original framebuffer so low-poly asset
+      // textures remain readable while still achieving a comic/cel palette.
+      color.rgb = mix(color.rgb, quantized, 0.82);
+      gl_FragColor = color;
+    }
+  `,
+};


### PR DESCRIPTION
### Motivation
- Provide a single, production-ready post-processing pipeline based on `EffectComposer` that is modular, configurable, and easy to extend. 
- Expose all effects through a single configuration object and named modes so effects can be toggled or reconfigured at runtime with minimal allocations. 
- Support high-DPI displays, dynamic resizing, and avoid extra GPU work by skipping disabled passes to preserve performance. 

### Description
- Added `js/three/postprocessing/PostProcessingManager.js`, a self-contained manager that owns an `EffectComposer` and creates per-effect passes (outline, toon quantization, bloom, color grading, film grain, CRT shader, pixelation, gamma) and applies a single configuration surface. 
- Added `js/three/postprocessing/PostProcessingConfig.js` containing `POST_PROCESSING_DEFAULTS` and `POST_PROCESSING_MODES` so all effects can be enabled/disabled and configured from one object. 
- Implemented modular shader passes in `js/three/postprocessing/shaders/*` for `ToonShader`, `CRTShader`, `ColorGradingShader`, `FilmGrainShader`, and `PixelationShader`, each in its own file to keep code modular and extendable. 
- Integrated the manager into the scene by wiring `ThreeScene` to instantiate `PostProcessingManager`, call `rendererEffects.render(delta)`, and forward `setQuality`/resize events into the manager so pixel ratio and sizes are handled centrally and UI rendering remains unaffected by pixelation. 
- Performance considerations: passes are created once, disabled passes are skipped via `enabled` flags, outline pass refreshes only when enabled, and the manager reuses composer buffers and honors a capped device pixel ratio. 

### Testing
- Ran `npm run build-css` successfully (Sass emitted `@import` deprecation warnings but build completed). 
- Ran `node --check` on `js/three/ThreeScene.js`, `js/three/postprocessing/PostProcessingManager.js`, `js/three/postprocessing/PostProcessingConfig.js`, and all shader modules under `js/three/postprocessing/shaders/`, and all checks passed. 
- Ran `git diff --check` to ensure repo whitespace/checks and no issues were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4982bc98b88333b00e1b0a81487e69)